### PR TITLE
Feature/view metadata (#69)

### DIFF
--- a/frontend/__tests__/Pages/AllData/AllData.test.jsx
+++ b/frontend/__tests__/Pages/AllData/AllData.test.jsx
@@ -4,6 +4,8 @@ import '@testing-library/jest-dom/extend-expect';
 import fetch from 'jest-fetch-mock';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 
 import { AllDataBody } from '../../../src/pages/allData/AllDataBody';
 
@@ -38,10 +40,14 @@ describe('Displays all top-level datasets', () => {
   // redux store
   let store;
 
+  // router history
+  let history;
+
   beforeEach(() => {
     fetch.resetMocks();
     const mockStore = configureStore();
     store = mockStore({});
+    history = createMemoryHistory();
   });
 
 
@@ -51,7 +57,9 @@ describe('Displays all top-level datasets', () => {
       findByText, getByText, queryAllByText,
     } = render(
       <Provider store={store}>
-        <AllDataBody />
+        <Router history={history}>
+          <AllDataBody />
+        </Router>
       </Provider>,
     );
 

--- a/frontend/__tests__/Pages/AllData/AllData.test.jsx
+++ b/frontend/__tests__/Pages/AllData/AllData.test.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import fetch from 'jest-fetch-mock';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+
+import { AllDataBody } from '../../../src/pages/allData/AllDataBody';
+
+global.fetch = fetch;
+
+const dataTypesResponse = `[
+  {
+    "name":"Car history",
+    "tags":[{
+      "tagName":"Public activity",
+      "metadataTypeName":"Car history"
+    },
+    {
+      "tagName":"Traffic",
+      "metadataTypeName":"Car history"
+    }],
+    "description":"Wroom wroom",
+    "metadataList":[]
+  },
+  {
+    "name":"Cycle history",
+    "tags":[{
+      "tagName":"Public activity",
+      "metadataTypeName":"Cycle history"
+    }],
+    "description":"Pling pling",
+    "metadataList":[]
+  }
+]`;
+
+describe('Displays all top-level datasets', () => {
+  // redux store
+  let store;
+
+  beforeEach(() => {
+    fetch.resetMocks();
+    const mockStore = configureStore();
+    store = mockStore({});
+  });
+
+
+  it('Shows the title and description of datasets', async () => {
+    fetch.mockResponseOnce(dataTypesResponse);
+    const {
+      findByText, getByText, queryAllByText,
+    } = render(
+      <Provider store={store}>
+        <AllDataBody />
+      </Provider>,
+    );
+
+    // wait for the data to load
+    await findByText(new RegExp('Car history'));
+    getByText(new RegExp('Cycle history'));
+
+    // Both car and cycle have the "Public activity" tag, car has the "traffic tag"
+    expect(queryAllByText(new RegExp('Traffic')).length).toBe(1);
+    expect(queryAllByText(new RegExp('Public activity')).length).toBe(2);
+
+    // should have fetched exactly once
+    expect(fetch.mock.calls.length).toEqual(1);
+  });
+});

--- a/frontend/__tests__/Pages/Inspection/Inspection.test.jsx
+++ b/frontend/__tests__/Pages/Inspection/Inspection.test.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import fetch from 'jest-fetch-mock';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+
+import { InspectionBody } from '../../../src/pages/Inspection/InspectionBody';
+
+global.fetch = fetch;
+
+const carHistoryResponse = `{
+  "name":"Car history",
+  "tags":[{
+    "tagName":"Public activity",
+    "metadataTypeName":"Car history"
+  },
+  {
+    "tagName":"Traffic",
+    "metadataTypeName":"Car history"
+  }],
+  "description":"Wroom wroom",
+  "metadataList":[{
+    "uuid":"3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "url":"https://trondheim.kommune.no",
+    "description":"",
+    "formatName":"JSON",
+    "releaseState":1,
+    "metadataTypeName":"Car history",
+    "municipalityName":"Trondheim"
+  },
+  {
+    "uuid": "3fa85f64-5717-4562-b3fc-2c963f66afb7",
+    "url":"https://bergen.kommune.no",
+    "description":"",
+    "formatName":"JSON",
+    "releaseState":1,
+    "metadataTypeName":"Car history",
+    "municipalityName":"Bergen"
+  }]
+}`;
+
+const carHistoryTrondheimResponse = `{
+  "uuid":"3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "url":"https://trondheim.kommune.no",
+  "description":"","formatName":"JSON",
+  "releaseState":2,
+  "metadataTypeName":"Car history",
+  "municipalityName":"Trondheim"
+}`;
+
+describe('Page displays bottom-level datasets from municipalities', () => {
+  // redux store
+  let store;
+
+  beforeEach(() => {
+    fetch.resetMocks();
+    const mockStore = configureStore();
+    store = mockStore({});
+  });
+
+
+  it('Shows the title and description of a single dataset', async () => {
+    // first fetches metadata about the specific set
+    fetch.mockResponseOnce(carHistoryTrondheimResponse);
+    // then, when name is specified, fetches more general data about the type
+    fetch.mockResponseOnce(carHistoryResponse);
+    const {
+      getByText, findByText, queryByText,
+    } = render(
+      <Provider store={store}>
+        <InspectionBody id="" />
+      </Provider>,
+    );
+
+    await findByText(new RegExp('Trondheim'));
+    getByText('Wroom wroom');
+    expect(queryByText(new RegExp('Bergen'))).toBeNull();
+
+    // should have fetched exactly twice, once for fetching municipalities and once for submitting.
+    expect(fetch.mock.calls.length).toEqual(2);
+  });
+});

--- a/frontend/__tests__/Pages/MetadataByType/MetadataByType.test.jsx
+++ b/frontend/__tests__/Pages/MetadataByType/MetadataByType.test.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import fetch from 'jest-fetch-mock';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+
+import { MetadataByTypeBody } from '../../../src/pages/MetadataByType/MetadataByTypeBody';
+
+global.fetch = fetch;
+
+const carHistoryResponse = `{
+  "name":"Car history",
+  "tags":[{
+    "tagName":"Public activity",
+    "metadataTypeName":"Car history"
+  },
+  {
+    "tagName":"Traffic",
+    "metadataTypeName":"Car history"
+  }],
+  "description":"Wroom wroom",
+  "metadataList":[{
+    "uuid":"3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "url":"https://trondheim.kommune.no",
+    "description":"",
+    "formatName":"JSON",
+    "releaseState":1,
+    "metadataTypeName":"Car history",
+    "municipalityName":"Trondheim"
+  },
+  {
+    "uuid": "3fa85f64-5717-4562-b3fc-2c963f66afb7",
+    "url":"https://bergen.kommune.no",
+    "description":"",
+    "formatName":"JSON",
+    "releaseState":2,
+    "metadataTypeName":"Car history",
+    "municipalityName":"Bergen"
+  }]
+}`;
+
+describe('Displays all bottom-level datasets with a given name', () => {
+  // redux store
+  let store;
+
+  beforeEach(() => {
+    fetch.resetMocks();
+    const mockStore = configureStore();
+    store = mockStore({});
+  });
+
+
+  it('Shows the title and description of datasets', async () => {
+    fetch.mockResponseOnce(carHistoryResponse);
+    const {
+      findByText, getByText, queryByText, queryAllByText,
+    } = render(
+      <Provider store={store}>
+        <MetadataByTypeBody name="Car history" />
+      </Provider>,
+    );
+
+    // wait for the data to load
+    await findByText('Trondheim');
+
+    // once Trondheim is there, Bergen should be too
+    getByText('Bergen');
+
+    // Trondheim is labeled released, Bergen as ready, and none others are there
+    expect(queryByText('Bodø')).toBeNull();
+    expect(queryAllByText('Released').length).toBe(1);
+    expect(queryAllByText('Ready to release').length).toBe(1);
+    expect(queryAllByText('Needs work').length).toBe(0);
+    expect(queryAllByText('Not releasable').length).toBe(0);
+
+    // should have fetched exactly once
+    expect(fetch.mock.calls.length).toEqual(1);
+  });
+});

--- a/frontend/__tests__/Pages/MetadataByType/MetadataByType.test.jsx
+++ b/frontend/__tests__/Pages/MetadataByType/MetadataByType.test.jsx
@@ -4,6 +4,8 @@ import '@testing-library/jest-dom/extend-expect';
 import fetch from 'jest-fetch-mock';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 
 import { MetadataByTypeBody } from '../../../src/pages/MetadataByType/MetadataByTypeBody';
 
@@ -44,10 +46,14 @@ describe('Displays all bottom-level datasets with a given name', () => {
   // redux store
   let store;
 
+  // router history
+  let history;
+
   beforeEach(() => {
     fetch.resetMocks();
     const mockStore = configureStore();
     store = mockStore({});
+    history = createMemoryHistory();
   });
 
 
@@ -57,7 +63,9 @@ describe('Displays all bottom-level datasets with a given name', () => {
       findByText, getByText, queryByText, queryAllByText,
     } = render(
       <Provider store={store}>
-        <MetadataByTypeBody name="Car history" />
+        <Router history={history}>
+          <MetadataByTypeBody name="Car history" />
+        </Router>
       </Provider>,
     );
 

--- a/frontend/src/pages/Inspection/Comment.jsx
+++ b/frontend/src/pages/Inspection/Comment.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+
+const Wrapper = styled.div`
+  font-size: 0.9em;
+  background-color: white;
+  padding: 0.8em;
+  border-radius: 0.8em;
+  margin-bottom: 0.8em;
+`;
+
+const CommentHeader = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
+const HeaderInfo = styled.p`
+  font-weight: 500;
+  color: ${(props) => props.color};
+`;
+
+const CommentBody = styled.div`
+  font-size: 0.9em;
+`;
+
+export const Comment = (props) => {
+  const { comment, author, date } = props;
+  return (
+    <Wrapper>
+      <CommentHeader>
+        <HeaderInfo color="3e3e3e">{author}</HeaderInfo>
+        <HeaderInfo color="dimgray">{date}</HeaderInfo>
+      </CommentHeader>
+      <CommentBody>
+        <p>{comment}</p>
+      </CommentBody>
+    </Wrapper>
+  );
+};
+
+Comment.propTypes = {
+  comment: PropTypes.string.isRequired,
+  author: PropTypes.string.isRequired,
+  date: PropTypes.string.isRequired,
+};

--- a/frontend/src/pages/Inspection/Comments.jsx
+++ b/frontend/src/pages/Inspection/Comments.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+import { Comment } from './Comment';
+
+const Wrapper = styled.div`
+  padding-left: 0.5em;
+  border-left: 0.1em solid #e4e4e4;
+  max-width: 30em;
+  min-width: 15em;
+`;
+
+export const Comments = (props) => {
+  const { comments } = props;
+  return (
+    <Wrapper>
+      <h2>Feedback</h2>
+      {comments.map(({
+        id, comment, author, date,
+      }) => (
+        <Comment
+          key={id}
+          comment={comment}
+          author={author}
+          date={date}
+        />
+      ))}
+    </Wrapper>
+  );
+};
+
+Comments.propTypes = {
+  comments: PropTypes.arrayOf(PropTypes.object).isRequired,
+};

--- a/frontend/src/pages/Inspection/InspectionBody.jsx
+++ b/frontend/src/pages/Inspection/InspectionBody.jsx
@@ -1,0 +1,105 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { useDispatch } from 'react-redux';
+
+import { MetaData } from './MetaData';
+import { alertActions } from '../../state/actions/alert';
+// import { Comments } from './Comments';
+
+const Wrapper = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+`;
+
+export const InspectionBody = (props) => {
+  const { id } = props;
+  const [data, setData] = useState({
+    uuid: id,
+    url: '',
+    formatName: '',
+    releaseState: 0,
+    metadataTypeName: '',
+    municipalityName: '',
+  });
+  // const [comments, setComments] = useState([]);
+  const [tags, setTags] = useState([]);
+  const [description, setDescription] = useState('');
+
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const internal = async () => {
+      try {
+        const res = await fetch(`/api/metadata/${id}`);
+        const { status, ok } = res;
+        if (!ok) {
+          const err = new Error();
+          err.status = status;
+          throw err;
+        }
+        const municipality = await res.json();
+        setData(municipality);
+      } catch (err) {
+        const { status } = err;
+        if (status === 404) {
+          dispatch(alertActions.error('Could not find the requested dataset.'));
+        } else {
+          dispatch(alertActions.error('Failed to fetch this data. Please try again later.'));
+        }
+      }
+
+      // get received comments when this is implemented backend
+      /*
+      setComments([{
+        id: 1,
+        comment: 'Beautiful comment',
+        author: 'Michael Bay',
+        date: '19-02-2019',
+      },
+      {
+        id: 2,
+        comment: 'Harsh comment',
+        author: 'Sharknado',
+        date: '23-07-2019',
+      }]);
+      */
+    };
+    internal();
+  }, [id]);
+
+  useEffect(() => {
+    const { metadataTypeName: name } = data;
+    if (name) {
+      const internal = async () => {
+        try {
+          const res = await fetch(`/api/MetadataType/${name}`);
+          const { ok } = res;
+          if (!ok) {
+            throw new Error();
+          }
+          const { tags: receivedTags, description: receivedDescription } = await res.json();
+          const tagNames = receivedTags.map(({ tagName }) => tagName);
+          setTags(tagNames);
+          setDescription(receivedDescription);
+        } catch (err) {
+          dispatch(alertActions.error('Failed to fetch information about the category'));
+        }
+      };
+      internal();
+    }
+  }, [data]);
+
+  return (
+    <Wrapper>
+      <MetaData data={data} description={description} tags={tags} />
+      {/* <Comments comments={comments} /> */}
+    </Wrapper>
+  );
+};
+
+InspectionBody.propTypes = {
+  id: PropTypes.string.isRequired,
+};

--- a/frontend/src/pages/Inspection/MetaData.jsx
+++ b/frontend/src/pages/Inspection/MetaData.jsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  max-width: 50em;
+  background-color: white;
+  max-width: 50em;
+  border: solid 0.2em #e4e4e4;
+  border-radius: 0.2em;
+  padding: 0;
+  margin: 0.5em;
+`;
+
+const DateLine = styled.p`
+  font-size: 0.8em;
+  color: dimgray;
+`;
+
+const Description = styled.p`
+  font-size: 0.9em;
+  color: #353535;
+`;
+
+const Tag = styled.div`
+  background-color: #eeeeee;
+  color: #595959;
+  font-size: 0.9em;
+  padding: 0.1em 0.7em;
+  display: inline-block;
+  border-radius: 1em;
+  margin: 0.3em;
+`;
+
+const Source = styled.a`
+  margin: 0.5em;
+  display: flex;
+  flex-direction: row;
+`;
+
+const FileFormat = styled.div`
+  background-color: #d8e3ff;
+  margin-left: 0.4em;
+  padding: 0 1em;
+  color: #434faf;
+`;
+
+export const MetaData = (props) => {
+  const { data, tags, description } = props;
+  const date = '20-09-2019';
+  const {
+    municipalityName, formatName, url, metadataTypeName,
+  } = data;
+  return (
+    <Wrapper>
+      <h2>
+        Showing metadata about dataset
+        {` ${metadataTypeName} from ${municipalityName}`}
+      </h2>
+      <DateLine>
+        Published
+        {` ${date}`}
+      </DateLine>
+      <Description>
+        {description}
+      </Description>
+      <div>
+        {tags.map((tag) => <Tag key={tag}>{tag}</Tag>)}
+      </div>
+      <div>
+        <Source href={url}>
+          {`[${url}]`}
+          <FileFormat>
+            <p>
+              {formatName}
+            </p>
+          </FileFormat>
+        </Source>
+      </div>
+    </Wrapper>
+  );
+};
+
+MetaData.propTypes = {
+  data: PropTypes.shape({
+    municipalityName: PropTypes.string.isRequired,
+    formatName: PropTypes.string.isRequired,
+    metadataTypeName: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+  }).isRequired,
+  description: PropTypes.string.isRequired,
+  tags: PropTypes.arrayOf(PropTypes.string).isRequired,
+};

--- a/frontend/src/pages/Inspection/index.jsx
+++ b/frontend/src/pages/Inspection/index.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
 
 import { Template } from '../../sharedComponents/Template';
@@ -12,12 +11,4 @@ export const Inspection = () => {
       <InspectionBody id={id} />
     </Template>
   );
-};
-
-Inspection.propTypes = {
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      id: PropTypes.string.isRequired,
-    }),
-  }).isRequired,
 };

--- a/frontend/src/pages/Inspection/index.jsx
+++ b/frontend/src/pages/Inspection/index.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useParams } from 'react-router-dom';
+
+import { Template } from '../../sharedComponents/Template';
+import { InspectionBody } from './InspectionBody';
+
+export const Inspection = () => {
+  const { id } = useParams();
+  return (
+    <Template>
+      <InspectionBody id={id} />
+    </Template>
+  );
+};
+
+Inspection.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+    }),
+  }).isRequired,
+};

--- a/frontend/src/pages/MetadataByType/MetadataByTypeBody.jsx
+++ b/frontend/src/pages/MetadataByType/MetadataByTypeBody.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 
 
 import { alertActions } from '../../state/actions/alert';
@@ -113,9 +114,9 @@ export const MetadataByTypeBody = ({ name }) => {
             .map(({ uuid, municipalityName, releaseState }) => (
               <tr key={uuid}>
                 <td>
-                  <a href={`/viewData/dataset/${uuid}`}>
+                  <Link to={`/viewData/dataset/${uuid}`}>
                     {municipalityName}
-                  </a>
+                  </Link>
                 </td>
                 <td>
                   {releaseStates[releaseState - 1]}

--- a/frontend/src/pages/MetadataByType/MetadataByTypeBody.jsx
+++ b/frontend/src/pages/MetadataByType/MetadataByTypeBody.jsx
@@ -1,0 +1,133 @@
+import React, { useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+
+import { alertActions } from '../../state/actions/alert';
+
+const Wrapper = styled.div`
+  flex: 1;
+  padding: 0.5em;
+`;
+
+const Tag = styled.div`
+  background-color: #eeeeee;
+  color: #595959;
+  font-size: 0.9em;
+  padding: 0.1em 0.7em;
+  display: inline-block;
+  border-radius: 1em;
+  margin: 0.3em;
+`;
+
+const State = styled.div`
+  padding: 0 0.4em;
+  background-color: ${({ color }) => color};
+`;
+
+const releaseStates = [
+  <State color="#9999dd">
+    Released
+  </State>,
+  <State color="#00ff00">
+    Ready to release
+  </State>,
+  <State color="#ffff33">
+    Needs work
+  </State>,
+  <State color="#cc4444">
+    Not releasable
+  </State>,
+];
+
+export const MetadataByTypeBody = ({ name }) => {
+  const [metadatas, setMetadatas] = useState([]);
+  const [tags, setTags] = useState([]);
+  const [description, setDescription] = useState('');
+  const [search, setSearch] = useState('');
+
+  // redux, for error messages
+  const dispatch = useDispatch();
+
+  // get list of municipalities offering the metadata
+  useEffect(() => {
+    const internal = async () => {
+      try {
+        const res = await fetch(`/api/metadataType/${name}`);
+        const { status, ok } = res;
+        if (!ok) {
+          const err = new Error();
+          err.status = status;
+          throw err;
+        }
+        const {
+          metadataList, tags: receivedTags, description: receivedDescription,
+        } = await res.json();
+        const tagNames = receivedTags.map(({ tagName }) => tagName);
+        setMetadatas(metadataList);
+        setTags(tagNames);
+        setDescription(receivedDescription);
+      } catch (err) {
+        const { status } = err;
+        if (status === 404) {
+          dispatch(alertActions.error('Could not find the dataset you requested.'));
+        } else {
+          dispatch(alertActions.error('Failed to fetch a list of municipalities offering this dataset. Please try again later.'));
+        }
+      }
+    };
+    internal();
+  }, [name]);
+
+  return (
+    <Wrapper>
+      <h1>
+        Metadata type:
+        {` ${name}`}
+      </h1>
+      <p>
+        {description}
+      </p>
+      <div>
+        {tags.map((tag) => (
+          <Tag key={tag}>
+            {tag}
+          </Tag>
+        ))}
+      </div>
+      <h3>This data set is offered by:</h3>
+      <input type="text" placeholder="Search" value={search} onChange={(e) => setSearch(e.target.value)} />
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Release state</th>
+          </tr>
+        </thead>
+        <tbody>
+          {metadatas
+            .filter(({ municipalityName }) => (
+              municipalityName.toLowerCase().includes(search.toLowerCase())
+            ))
+            .map(({ uuid, municipalityName, releaseState }) => (
+              <tr key={uuid}>
+                <td>
+                  <a href={`/viewData/dataset/${uuid}`}>
+                    {municipalityName}
+                  </a>
+                </td>
+                <td>
+                  {releaseStates[releaseState - 1]}
+                </td>
+              </tr>
+            ))}
+        </tbody>
+      </table>
+    </Wrapper>
+  );
+};
+
+MetadataByTypeBody.propTypes = {
+  name: PropTypes.string.isRequired,
+};

--- a/frontend/src/pages/MetadataByType/index.jsx
+++ b/frontend/src/pages/MetadataByType/index.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useParams } from 'react-router-dom';
+
+import { Template } from '../../sharedComponents/Template';
+import { MetadataByTypeBody } from './MetadataByTypeBody';
+
+export const MetadataByType = () => {
+  const { name } = useParams();
+  return (
+    <Template>
+      <MetadataByTypeBody name={name} />
+    </Template>
+  );
+};
+
+MetadataByType.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+    }),
+  }).isRequired,
+};

--- a/frontend/src/pages/MetadataByType/index.jsx
+++ b/frontend/src/pages/MetadataByType/index.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
 
 import { Template } from '../../sharedComponents/Template';
@@ -12,12 +11,4 @@ export const MetadataByType = () => {
       <MetadataByTypeBody name={name} />
     </Template>
   );
-};
-
-MetadataByType.propTypes = {
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      name: PropTypes.string.isRequired,
-    }),
-  }).isRequired,
 };

--- a/frontend/src/pages/allData/AllDataBody.jsx
+++ b/frontend/src/pages/allData/AllDataBody.jsx
@@ -1,0 +1,95 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { useDispatch } from 'react-redux';
+
+import { alertActions } from '../../state/actions/alert';
+
+const OuterWrapper = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Types = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Type = styled.div`
+  max-width: 60em;
+  border: solid 0.2em #f0f0f0;
+  border-radius: 0.2em;
+  padding: 0.5em;
+  margin-bottom: 0.5em;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Tags = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+`;
+
+const Tag = styled.div`
+  background-color: #eeeeee;
+  color: #595959;
+  font-size: 0.9em;
+  padding: 0.1em 0.7em;
+  display: inline-block;
+  border-radius: 1em;
+  margin: 0.3em;
+`;
+
+
+export const AllDataBody = () => {
+  const [metadataTypes, setMetadataTypes] = useState([]);
+
+  const dispatch = useDispatch();
+
+  // get metadata types
+  useEffect(() => {
+    const internal = async () => {
+      try {
+        const res = await fetch('/api/metadataType');
+        const { ok } = res;
+        if (!ok) {
+          throw new Error();
+        }
+        const j = await res.json();
+        setMetadataTypes(j);
+      } catch (err) {
+        dispatch(alertActions.error('Failed to fetch metadata categories'));
+      }
+    };
+    internal();
+  }, []);
+
+  // get all metadata:
+  return (
+    <OuterWrapper>
+      <h1>All datasets</h1>
+      <Types>
+        <div>
+          {metadataTypes.map(({ name, tags, description }) => (
+            <Type key={name}>
+              <a href={`/viewData/dataType/${name}`}>
+                <h3>
+                  {name}
+                </h3>
+              </a>
+              <p>
+                {description}
+              </p>
+              <Tags>
+                {tags.map(({ tagName }) => (
+                  <Tag key={tagName}>{tagName}</Tag>
+                ))}
+              </Tags>
+            </Type>
+          ))}
+        </div>
+      </Types>
+    </OuterWrapper>
+  );
+};

--- a/frontend/src/pages/allData/AllDataBody.jsx
+++ b/frontend/src/pages/allData/AllDataBody.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { useDispatch } from 'react-redux';
+import { Link } from 'react-router-dom';
 
 import { alertActions } from '../../state/actions/alert';
 
@@ -73,11 +74,11 @@ export const AllDataBody = () => {
         <div>
           {metadataTypes.map(({ name, tags, description }) => (
             <Type key={name}>
-              <a href={`/viewData/dataType/${name}`}>
+              <Link to={`/viewData/dataType/${name}`}>
                 <h3>
                   {name}
                 </h3>
-              </a>
+              </Link>
               <p>
                 {description}
               </p>

--- a/frontend/src/pages/allData/index.jsx
+++ b/frontend/src/pages/allData/index.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { Template } from '../../sharedComponents/Template';
+import { AllDataBody } from './AllDataBody';
+
+
+export const AllData = () => (
+  <Template>
+    <AllDataBody />
+  </Template>
+);

--- a/frontend/src/router/router.jsx
+++ b/frontend/src/router/router.jsx
@@ -9,6 +9,9 @@ import PrivateRoute from './PrivateRoute';
 
 // Pages
 import { Splash } from '../pages/Splash';
+import { AllData } from '../pages/allData';
+import { MetadataByType } from '../pages/MetadataByType';
+import { Inspection } from '../pages/Inspection';
 import { SendMetadata } from '../pages/sendMetadata/SendMetadata';
 import { Error404 } from '../pages/Errors';
 import { Login } from '../pages/Login';
@@ -20,6 +23,9 @@ const RouterComponent = () => { // eslint-disable-line arrow-body-style
     <Router history={history}>
       <Switch>
         <Route exact path="/" component={Splash} />
+        <Route exact path="/viewData" component={AllData} />
+        <Route path="/viewData/dataType/:name" component={MetadataByType} />
+        <Route path="/viewData/dataset/:id" component={Inspection} />
         <Route path="/sendData" component={SendMetadata} />
         <PrivateRoute path="/login" loggedOut component={Login} />
         <PrivateRoute path="/register" loggedOut component={Register} />


### PR DESCRIPTION
Closes #27, closes #54, closes #55 
Added three new pages, corresponding to the three stories:
* Story 1: See which data sets are available
  * Added the component AllData, available at the route /viewData
  * Each dataset can be clicked, which redirects you to the list of municipalities offering the dataset

* Story 2: See which municipalities provide a certain dataset
  * Added the component MetadataByType
  * Contains a search field that filters the data on municipality names, in case a lot of the municipalities have a given dataset
    * Filtering is done frontend, since the max is ~350 which computationally isn't very heavy
  * Each municipality name can be clicked to see closer inspection of the specific dataset

* Story 13: See details about a single dataset from a municipality
  * Added the component Inspection
  * Shows info about the specific dataset from a single municipality