### PR TITLE
Feature/qo l change splash category view

### DIFF
--- a/frontend/__tests__/App.test.jsx
+++ b/frontend/__tests__/App.test.jsx
@@ -38,7 +38,7 @@ test('renders learn react link', () => {
   );
 
   // Learn react should be rendered
-  const linkElement = getByText(/learn react/i);
+  const linkElement = getByText(/all datasets/i);
   expect(linkElement).toBeInTheDocument();
 
   // No alert is rendered

--- a/frontend/__tests__/Pages/Login.test.jsx
+++ b/frontend/__tests__/Pages/Login.test.jsx
@@ -66,9 +66,9 @@ describe('Template component', () => {
     });
 
     const expectedActions = store.getActions();
-    expect(expectedActions.length).toBe(3);
-    expect(expectedActions[1]).toEqual({ type: 'USER_SET_USER_LOGIN_REQUEST' });
-    expect(expectedActions[2]).toEqual({
+    expect(expectedActions.length).toBe(4);
+    expect(expectedActions[2]).toEqual({ type: 'USER_SET_USER_LOGIN_REQUEST' });
+    expect(expectedActions[3]).toEqual({
       type: 'USER_SET_USER_LOGIN_SUCCESS',
       user: { email: 'test@baerum.kommune.no', type: 'kommune' },
     });

--- a/frontend/__tests__/Pages/Register.test.jsx
+++ b/frontend/__tests__/Pages/Register.test.jsx
@@ -95,9 +95,9 @@ describe('Template component', () => {
     });
 
     const expectedActions = store.getActions();
-    expect(expectedActions.length).toBe(4);
-    expect(expectedActions[2]).toEqual({ type: 'USER_SET_USER_REGISTRATION_REQUEST' });
-    expect(expectedActions[3]).toEqual({
+    expect(expectedActions.length).toBe(5);
+    expect(expectedActions[3]).toEqual({ type: 'USER_SET_USER_REGISTRATION_REQUEST' });
+    expect(expectedActions[4]).toEqual({
       type: 'USER_SET_USER_REGISTRATION_SUCCESS',
     });
   });

--- a/frontend/src/pages/MetadataByMunicipality/SingleMetaDataResult.jsx
+++ b/frontend/src/pages/MetadataByMunicipality/SingleMetaDataResult.jsx
@@ -101,7 +101,7 @@ const SingleMetaDataResult = ({ metadata }) => {
             <h2>{metadataTypeName}</h2>
           </MetaDataTypeLink>
           <p>{description}</p>
-          <MetaDataLink to={`viewData/dataset/${uuid}`}>Other municipalities who offer this data</MetaDataLink>
+          <MetaDataLink to={`/dataset/${uuid}`}>Other municipalities who offer this data</MetaDataLink>
         </MetaDataDescription>
         <URLWrapper href={url}>
           <URL>{url}</URL>

--- a/frontend/src/pages/MetadataByMunicipality/SingleMetaDataResult.jsx
+++ b/frontend/src/pages/MetadataByMunicipality/SingleMetaDataResult.jsx
@@ -97,7 +97,7 @@ const SingleMetaDataResult = ({ metadata }) => {
       <MetaDataContent>
         <MetaDataDescription>
           <ReleaseStateLabel releaseState={releaseState} />
-          <MetaDataTypeLink to={`/viewData/dataType/${metadataTypeName}`}>
+          <MetaDataTypeLink to={`/dataType/${metadataTypeName}`}>
             <h2>{metadataTypeName}</h2>
           </MetaDataTypeLink>
           <p>{description}</p>

--- a/frontend/src/pages/MetadataByType/MetadataByTypeBody.jsx
+++ b/frontend/src/pages/MetadataByType/MetadataByTypeBody.jsx
@@ -114,7 +114,7 @@ export const MetadataByTypeBody = ({ name }) => {
             .map(({ uuid, municipalityName, releaseState }) => (
               <tr key={uuid}>
                 <td>
-                  <Link to={`/viewData/dataset/${uuid}`}>
+                  <Link to={`/dataset/${uuid}`}>
                     {municipalityName}
                   </Link>
                 </td>

--- a/frontend/src/pages/SendMetadata/MetadataForm.jsx
+++ b/frontend/src/pages/SendMetadata/MetadataForm.jsx
@@ -129,7 +129,7 @@ export const MetadataForm = () => {
   };
 
   if (submissionStatus === 'success') {
-    return <Redirect to="/viewData" />;
+    return <Redirect to="/" />;
   }
 
   const {

--- a/frontend/src/pages/Splash/index.jsx
+++ b/frontend/src/pages/Splash/index.jsx
@@ -3,59 +3,12 @@ import styled, { keyframes } from 'styled-components';
 
 import { Template } from '../../sharedComponents/Template';
 import logo from '../../assets/logo.svg';
-
-const AppLogoSpin = keyframes`
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-`;
-
-const AppLogo = styled.img`
-  height: 40vmin;
-  pointer-events: none;
-
-  @media (prefers-reduced-motion: no-preference) {
-    animation: ${AppLogoSpin} infinite 20s linear;
-  }
-`;
-
-const SplashWrapper = styled.div`
-  background-color: #282c34;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-  text-align: center;
-`;
-
-const AppLink = styled.a`
-  color: #61dafb;
-`;
+import { AllDataBody } from '../allData/AllDataBody';
 
 const Splash = () => { // eslint-disable-line arrow-body-style
   return (
     <Template>
-      <SplashWrapper>
-        <AppLogo src={logo} alt="logo" />
-        <p>
-          Edit
-          <code>src/App.js</code>
-          and save to reload.
-        </p>
-        <AppLink
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </AppLink>
-      </SplashWrapper>
+      <AllDataBody />
     </Template>
   );
 };

--- a/frontend/src/pages/Splash/index.jsx
+++ b/frontend/src/pages/Splash/index.jsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import styled, { keyframes } from 'styled-components';
-
 import { Template } from '../../sharedComponents/Template';
-import logo from '../../assets/logo.svg';
 import { AllDataBody } from '../allData/AllDataBody';
 
 const Splash = () => { // eslint-disable-line arrow-body-style

--- a/frontend/src/pages/allData/AllDataBody.jsx
+++ b/frontend/src/pages/allData/AllDataBody.jsx
@@ -74,7 +74,7 @@ export const AllDataBody = () => {
         <div>
           {metadataTypes.map(({ name, tags, description }) => (
             <Type key={name}>
-              <Link to={`/viewData/dataType/${name}`}>
+              <Link to={`/dataType/${name}`}>
                 <h3>
                   {name}
                 </h3>

--- a/frontend/src/router/router.jsx
+++ b/frontend/src/router/router.jsx
@@ -9,7 +9,6 @@ import PrivateRoute from './PrivateRoute';
 
 // Pages
 import { Splash } from '../pages/Splash';
-import { AllData } from '../pages/allData';
 import { MetadataByType } from '../pages/MetadataByType';
 import { Inspection } from '../pages/Inspection';
 import { Article } from '../pages/Article';

--- a/frontend/src/router/router.jsx
+++ b/frontend/src/router/router.jsx
@@ -27,9 +27,8 @@ const RouterComponent = () => { // eslint-disable-line arrow-body-style
     <Router history={history}>
       <Switch>
         <Route exact path="/" component={Splash} />
-        <Route exact path="/viewData" component={AllData} />
-        <Route path="/viewData/dataType/:name" component={MetadataByType} />
-        <Route path="/viewData/dataset/:id" component={Inspection} />
+        <Route path="/dataType/:name" component={MetadataByType} />
+        <Route path="/dataset/:id" component={Inspection} />
         <PrivateRoute path="/sendData" municipality component={SendMetadata} />
         <PrivateRoute path="/articles/new/:id" municipality component={NewExperienceArticle} />
         <PrivateRoute path="/articles/new" municipality component={NewExperienceArticle} />

--- a/frontend/src/sharedComponents/SubHeader.jsx
+++ b/frontend/src/sharedComponents/SubHeader.jsx
@@ -28,7 +28,7 @@ const SubHeader = () => {
   return (
     <SubHeaderContainer>
       <LinkStyled to="/municipalities">Search by municipality</LinkStyled>
-      <LinkStyled to="/viewData">Search by category</LinkStyled>
+      <LinkStyled to="/">Search by category</LinkStyled>
       {
         role === 1
           ? <LinkStyled to="/sendData">Submit data</LinkStyled>


### PR DESCRIPTION
Changes the splash to display the category view. All routing is changed so that /viewData is no longer a thing, instead urls will look like 

> domain.com/dataType/_result_

instead of 

> domain.com/viewData/dataType/_result_

I have tested it with sample data sets and types and have found no issues.
Resolves #126 

The **subheader and header have not been changed**. I suggest doing this in a separate issue, because the customer wanted significant changes (everything currently in header should be in the footer, and everything currently in the subfooter should be in the header). There's also the issue of not having the user attempt to click on the category view from the splash, because the category view **is** the splash. That's more of a design question than anything else.