### PR TITLE
Feature/comment system backend

### DIFF
--- a/backend/Controllers/CommentController.cs
+++ b/backend/Controllers/CommentController.cs
@@ -113,5 +113,21 @@ namespace OpenData.Controllers
             CommentResource retComment = mapper.Map<Comment, CommentResource>(comment);
             return Ok(retComment);
         }
+
+        /// <summary>
+        /// Used to GET child comments related to a given comment.
+        /// </summary>
+        /// <param name="commentUuid">CommentUuid for the parent comment</param>
+        /// <returns>The child comments for a given comment, and 5 levels depth (not including the comment itself)</returns>
+        [HttpGet("childcomments/{commentUuid}")]
+        public async Task<IActionResult> FetchChildComments(Guid commentUuid)
+        {
+            if (commentUuid == null)
+                return BadRequest("Invalid comment UUID");
+            
+            IEnumerable<Comment> comments = await commentService.FetchChildComments(commentUuid);
+            var retComments = mapper.Map<IEnumerable<Comment>, IEnumerable<CommentResource>>(comments);
+            return Ok(retComments);
+        }
     }
 }

--- a/backend/Controllers/CommentController.cs
+++ b/backend/Controllers/CommentController.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+using AutoMapper;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Http;
+
+using OpenData.Domain.Services;
+using OpenData.Resources;
+using OpenData.Domain.Models;
+
+namespace OpenData.Controllers
+{
+    [Authorize]
+    [Route("/api/[controller]")]
+    public class CommentController : Controller
+    {
+        private readonly ICommentService commentService;
+        private readonly IHttpContextAccessor httpContextRetriever;
+        private readonly IMapper mapper;
+
+        public CommentController(ICommentService commentService, IHttpContextAccessor httpContextRetriever, IMapper mapper)
+        {
+            this.commentService = commentService;
+            this.httpContextRetriever = httpContextRetriever;
+            this.mapper = mapper;
+        }
+
+        /// <summary>
+        /// Used to PUT comments related to a given Metadata.
+        /// </summary>
+        /// <param name="metadataUuid"></param>
+        /// <param name="newComment">New comment to be added.</param>
+        /// <returns>The comment if it was added successfully</returns>
+        [HttpPut("metadata/{metadataUuid}")]
+        public async Task<IActionResult> PutCommentForMetadataAsync(Guid metadataUuid, [FromBody] NewCommentResource newComment)
+        {
+            Comment comment = mapper.Map<NewCommentResource, Comment>(newComment);
+            comment.UserMail = httpContextRetriever.HttpContext.User.Identity.Name;
+
+            await commentService.AddRootCommentToMetadataAsync(metadataUuid, comment);
+            CommentResource retComment = mapper.Map<Comment, CommentResource>(comment);
+            return Ok(retComment);
+        }
+
+        /// <summary>
+        /// Fethes all the comments by a given metadata GUID.
+        /// </summary>
+        /// <param name="uuid"></param>
+        /// <returns>All of the comments for a given metadata GUID</returns>
+        [AllowAnonymous]
+        [HttpGet("metadata/{metadataUuid}")]
+        public async Task<IActionResult> GetCommentsForMetadataAsync(Guid metadataUuid)
+        {
+            IEnumerable<Comment> comments = await commentService.FetchCommentsForMetadataAsync(metadataUuid);
+            var retComments = mapper.Map<IEnumerable<Comment>, IEnumerable<CommentResource>>(comments);
+            return Ok(retComments);
+        }
+
+        /// <summary>
+        /// Used to PUT comments related to a given experience post.
+        /// </summary>
+        /// <param name="experiencePostUuid"></param>
+        /// <param name="newComment">New comment to be added.</param>
+        /// <returns>The comment if it was added successfully</returns>
+        [HttpPut("experiencepost/{experiencePostUuid}")]
+        public async Task<IActionResult> PutCommentForExperiencePostAsync(Guid experiencePostUuid, [FromBody] NewCommentResource newComment)
+        {
+            Comment comment = mapper.Map<NewCommentResource, Comment>(newComment);
+            comment.UserMail = httpContextRetriever.HttpContext.User.Identity.Name;
+
+            await commentService.AddRootCommentToExperiencePostAsync(experiencePostUuid, comment);
+            CommentResource retComment = mapper.Map<Comment, CommentResource>(comment);
+            return Ok(retComment);
+        }
+
+        /// <summary>
+        /// Fethes all the comments by a given experience post GUID.
+        /// </summary>
+        /// <param name="uuid"></param>
+        /// <returns>All of the comments for a given experience post GUID</returns>
+        [AllowAnonymous]
+        [HttpGet("experiencepost/{experiencePostUuid}")]
+        public async Task<IActionResult> GetCommentsForExperiencePostAsync(Guid experiencePostUuid)
+        {
+            IEnumerable<Comment> comments = await commentService.FetchCommentsForExperiencePostAsync(experiencePostUuid);
+            var retComments = mapper.Map<IEnumerable<Comment>, IEnumerable<CommentResource>>(comments);
+            return Ok(retComments);
+        }
+
+        /// <summary>
+        /// Used to PUT comments related to a given comment.
+        /// </summary>
+        /// <param name="commentUuid">CommentUuid for the parent comment</param>
+        /// <param name="newComment">New comment to be added.</param>
+        /// <returns>The comment if it was added successfully</returns>
+        [HttpPut("reply/{commentUuid}")]
+        public async Task<IActionResult> ReplyToCommentAsync(Guid commentUuid, [FromBody] NewCommentResource newComment)
+        {
+            if(commentUuid == null)
+                return BadRequest("Invalid comment UUID");
+
+            Comment comment = mapper.Map<NewCommentResource, Comment>(newComment);
+            comment.UserMail = httpContextRetriever.HttpContext.User.Identity.Name;
+            comment.ParentCommentUuid = commentUuid;
+
+            await commentService.ReplyToCommentAsync(comment);
+            CommentResource retComment = mapper.Map<Comment, CommentResource>(comment);
+            return Ok(retComment);
+        }
+    }
+}

--- a/backend/Controllers/ExperiencePostController.cs
+++ b/backend/Controllers/ExperiencePostController.cs
@@ -13,6 +13,8 @@ using OpenData.Exceptions;
 
 using System;
 using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Authorization;
 
 namespace OpenData.Controllers
 {
@@ -23,13 +25,17 @@ namespace OpenData.Controllers
 		private readonly IMapper _mapper;
 		private readonly IUnitOfWork _unitOfWork;
 		private readonly ITagService _tagService;
+		private readonly IHttpContextAccessor httpContextRetriever;
+		private readonly ICommentService commentService;
 
-		public ExperiencePostController(IExperiencePostService metadataService, IMapper mapper, IUnitOfWork unitOfWork, ITagService tagService) 
+		public ExperiencePostController(IExperiencePostService metadataService, IMapper mapper, IUnitOfWork unitOfWork, ITagService tagService, ICommentService commentService, IHttpContextAccessor httpContextRetriever) 
 		{
 			_experiencePostService = metadataService;
 			_mapper = mapper;
 			_unitOfWork = unitOfWork;
 			_tagService = tagService;
+			this.commentService = commentService;
+			this.httpContextRetriever = httpContextRetriever;
 		}
 
 		//TODO this needs authentication
@@ -91,6 +97,34 @@ namespace OpenData.Controllers
 
 			await _unitOfWork.CompleteAsync();
 			return Ok(res);
+		}
+
+		/// <summary>
+		/// Used to PUT comments related to a given Metadata.
+		/// </summary>
+		/// <param name="experiencePostGuid"></param>
+		/// <param name="newComment">New comment to be added.</param>
+		/// <returns>The comment if it was added successfully</returns>
+		[HttpPut("{metadataGuid}/comments")]
+		public async Task<IActionResult> PostCommentAsync(Guid experiencePostGuid, [FromBody] NewCommentResource newComment)
+		{
+			Comment comment = _mapper.Map<NewCommentResource, Comment>(newComment);
+			comment.UserMail = httpContextRetriever.HttpContext.User.Identity.Name;
+
+			await commentService.AddRootCommentToExperiencePostAsync(experiencePostGuid, comment);
+			return Ok(comment);
+		}
+
+		/// <summary>
+		/// Fethes all the comments by a given metadata GUID.
+		/// </summary>
+		/// <param name="uuid"></param>
+		/// <returns>All of the comments for a given metadata GUID</returns>
+		[HttpGet("{metadataGuid}/comments")]
+		public async Task<IActionResult> GetCommentsAsync([FromBody] Guid metadataGuid)
+		{
+			IEnumerable<Comment> comments = await commentService.FetchCommentsForMetadataAsync(metadataGuid);
+			return Ok(comments);
 		}
 	}
 }

--- a/backend/Controllers/ExperiencePostController.cs
+++ b/backend/Controllers/ExperiencePostController.cs
@@ -98,33 +98,5 @@ namespace OpenData.Controllers
 			await _unitOfWork.CompleteAsync();
 			return Ok(res);
 		}
-
-		/// <summary>
-		/// Used to PUT comments related to a given Metadata.
-		/// </summary>
-		/// <param name="experiencePostGuid"></param>
-		/// <param name="newComment">New comment to be added.</param>
-		/// <returns>The comment if it was added successfully</returns>
-		[HttpPut("{metadataGuid}/comments")]
-		public async Task<IActionResult> PostCommentAsync(Guid experiencePostGuid, [FromBody] NewCommentResource newComment)
-		{
-			Comment comment = _mapper.Map<NewCommentResource, Comment>(newComment);
-			comment.UserMail = httpContextRetriever.HttpContext.User.Identity.Name;
-
-			await commentService.AddRootCommentToExperiencePostAsync(experiencePostGuid, comment);
-			return Ok(comment);
-		}
-
-		/// <summary>
-		/// Fethes all the comments by a given metadata GUID.
-		/// </summary>
-		/// <param name="uuid"></param>
-		/// <returns>All of the comments for a given metadata GUID</returns>
-		[HttpGet("{metadataGuid}/comments")]
-		public async Task<IActionResult> GetCommentsAsync([FromBody] Guid metadataGuid)
-		{
-			IEnumerable<Comment> comments = await commentService.FetchCommentsForMetadataAsync(metadataGuid);
-			return Ok(comments);
-		}
 	}
 }

--- a/backend/Controllers/MetadataController.cs
+++ b/backend/Controllers/MetadataController.cs
@@ -133,5 +133,22 @@ namespace OpenData.Controllers
 
             return Unauthorized("Invalid permissions!");
 		}
+
+        [HttpPut("{uuid}/comments")]
+        public async Task<IActionResult> PostCommentAsync(string uuid, Comment comment)
+        {
+			comment.MetadataUuid = uuid;
+
+			await _metadataService.AddCommentAsync(comment);
+			return Ok(comment);
+        }
+
+		[HttpGet("{uuid}/comments")]
+		public async Task<IActionResult> GetCommentsAsync(string uuid)
+		{
+            
+			return Ok();
+		}
+
 	}
 }

--- a/backend/Controllers/MetadataController.cs
+++ b/backend/Controllers/MetadataController.cs
@@ -30,6 +30,7 @@ namespace OpenData.Controllers
 		private readonly IUnitOfWork _unitOfWork;
 		private readonly IHttpContextAccessor httpContextRetriever;
 		private readonly IUserService userService;
+		private readonly ICommentService commentService;
 
 		public MetadataController(
             IMetadataService metadataService,
@@ -37,7 +38,8 @@ namespace OpenData.Controllers
             IMapper mapper,
             IUnitOfWork unitOfWork,
 			IHttpContextAccessor httpContextRetriever,
-            IUserService userService
+            IUserService userService,
+			ICommentService commentService
             )
 		{
 			_metadataService = metadataService;
@@ -46,6 +48,7 @@ namespace OpenData.Controllers
 			_experiencePostService = experiencePostService;
 			this.httpContextRetriever = httpContextRetriever;
 			this.userService = userService;
+			this.commentService = commentService;
 		}
 
 		[AllowAnonymous]
@@ -147,7 +150,7 @@ namespace OpenData.Controllers
 			comment.MetadataUuid = metadataGuid;
 			comment.UserMail = httpContextRetriever.HttpContext.User.Identity.Name;
 
-			comment = await _metadataService.AddCommentAsync(comment);
+			comment = await commentService.AddRootCommentToMetadataAsync(comment);
 			return Ok(comment);
         }
 

--- a/backend/Controllers/MetadataController.cs
+++ b/backend/Controllers/MetadataController.cs
@@ -134,20 +134,34 @@ namespace OpenData.Controllers
             return Unauthorized("Invalid permissions!");
 		}
 
-        [HttpPut("{uuid}/comments")]
-        public async Task<IActionResult> PostCommentAsync(string uuid, Comment comment)
+        /// <summary>
+        /// Used to PUT comments related to a given Metadata.
+        /// </summary>
+        /// <param name="metadataGuid"></param>
+        /// <param name="newComment">New comment to be added.</param>
+        /// <returns>The comment if it was added successfully</returns>
+        [HttpPut("{metadataGuid}/comments")]
+        public async Task<IActionResult> PostCommentAsync(Guid metadataGuid, [FromBody] NewCommentResource newComment)
         {
-			comment.MetadataUuid = uuid;
+			Comment comment = _mapper.Map<NewCommentResource, Comment>(newComment);
+			comment.MetadataUuid = metadataGuid;
+			comment.UserMail = httpContextRetriever.HttpContext.User.Identity.Name;
 
-			await _metadataService.AddCommentAsync(comment);
+			comment = await _metadataService.AddCommentAsync(comment);
 			return Ok(comment);
         }
 
-		[HttpGet("{uuid}/comments")]
-		public async Task<IActionResult> GetCommentsAsync(string uuid)
+        /// <summary>
+        /// Fethes all the comments by a given metadata GUID.
+        /// </summary>
+        /// <param name="uuid"></param>
+        /// <returns>All of the comments for a given metadata GUID</returns>
+        [AllowAnonymous]
+		[HttpGet("{metadataGuid}/comments")]
+		public async Task<IActionResult> GetCommentsAsync([FromBody] Guid metadataGuid)
 		{
-            
-			return Ok();
+			IEnumerable<Comment> comments = await _metadataService.FetchCommentsAsync(metadataGuid);
+			return Ok(comments);
 		}
 
 	}

--- a/backend/Controllers/MetadataController.cs
+++ b/backend/Controllers/MetadataController.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 
 using AutoMapper;

--- a/backend/Controllers/MetadataController.cs
+++ b/backend/Controllers/MetadataController.cs
@@ -30,7 +30,6 @@ namespace OpenData.Controllers
 		private readonly IUnitOfWork _unitOfWork;
 		private readonly IHttpContextAccessor httpContextRetriever;
 		private readonly IUserService userService;
-		private readonly ICommentService commentService;
 
 		public MetadataController(
             IMetadataService metadataService,
@@ -48,7 +47,6 @@ namespace OpenData.Controllers
 			_experiencePostService = experiencePostService;
 			this.httpContextRetriever = httpContextRetriever;
 			this.userService = userService;
-			this.commentService = commentService;
 		}
 
 		[AllowAnonymous]
@@ -135,36 +133,6 @@ namespace OpenData.Controllers
 			}
 
             return Unauthorized("Invalid permissions!");
-		}
-
-        /// <summary>
-        /// Used to PUT comments related to a given Metadata.
-        /// </summary>
-        /// <param name="metadataGuid"></param>
-        /// <param name="newComment">New comment to be added.</param>
-        /// <returns>The comment if it was added successfully</returns>
-        [HttpPut("{metadataGuid}/comments")]
-        public async Task<IActionResult> PostCommentAsync(Guid metadataGuid, [FromBody] NewCommentResource newComment)
-        {
-			Comment comment = _mapper.Map<NewCommentResource, Comment>(newComment);
-			comment.MetadataUuid = metadataGuid;
-			comment.UserMail = httpContextRetriever.HttpContext.User.Identity.Name;
-
-			comment = await commentService.AddRootCommentToMetadataAsync(comment);
-			return Ok(comment);
-        }
-
-        /// <summary>
-        /// Fethes all the comments by a given metadata GUID.
-        /// </summary>
-        /// <param name="uuid"></param>
-        /// <returns>All of the comments for a given metadata GUID</returns>
-        [AllowAnonymous]
-		[HttpGet("{metadataGuid}/comments")]
-		public async Task<IActionResult> GetCommentsAsync([FromBody] Guid metadataGuid)
-		{
-			IEnumerable<Comment> comments = await _metadataService.FetchCommentsAsync(metadataGuid);
-			return Ok(comments);
 		}
 
 	}

--- a/backend/Domain/Models/Comment.cs
+++ b/backend/Domain/Models/Comment.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 
@@ -13,10 +15,17 @@ namespace OpenData.Domain.Models
         public string UserMail { get; set; }
         public User User { get; set; }
 
+        [Required]
         [ForeignKey("Metadata")]
-        public string MetadataUuid { get; set; }
+        public Guid MetadataUuid { get; set; }
         public Metadata Metadata { get; set; }
 
+        [ForeignKey("ParentComment")]
+        public Guid ParentCommentGuid { get; set; }
+        public Comment ParentComment { get; set; }
+        public IList<Comment> ChildComments { get; set; }
+
+        [Required]
         public string Content { get; set; }
 
         [DatabaseGenerated(DatabaseGeneratedOption.Computed)]

--- a/backend/Domain/Models/Comment.cs
+++ b/backend/Domain/Models/Comment.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations.Schema;
+
+
+namespace OpenData.Domain.Models
+{
+    public class Comment
+    {
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public Guid Uuid { get; set; }
+
+        [ForeignKey("User")]
+        public string UserMail { get; set; }
+        public User User { get; set; }
+
+        public string Content { get; set; }
+
+        [DatabaseGenerated(DatabaseGeneratedOption.Computed)]
+        public DateTime Published { get; set; }
+
+        [DatabaseGenerated(DatabaseGeneratedOption.Computed)]
+        public DateTime Edited { get; set; }
+    }
+}

--- a/backend/Domain/Models/Comment.cs
+++ b/backend/Domain/Models/Comment.cs
@@ -13,6 +13,10 @@ namespace OpenData.Domain.Models
         public string UserMail { get; set; }
         public User User { get; set; }
 
+        [ForeignKey("Metadata")]
+        public string MetadataUuid { get; set; }
+        public Metadata Metadata { get; set; }
+
         public string Content { get; set; }
 
         [DatabaseGenerated(DatabaseGeneratedOption.Computed)]

--- a/backend/Domain/Models/Comment.cs
+++ b/backend/Domain/Models/Comment.cs
@@ -11,26 +11,22 @@ namespace OpenData.Domain.Models
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public Guid Uuid { get; set; }
 
+        [Required]
         [ForeignKey("User")]
         public string UserMail { get; set; }
         public User User { get; set; }
 
-        [Required]
-        [ForeignKey("Metadata")]
-        public Guid MetadataUuid { get; set; }
-        public Metadata Metadata { get; set; }
-
         [ForeignKey("ParentComment")]
-        public Guid ParentCommentGuid { get; set; }
-        public Comment ParentComment { get; set; }
-        public IList<Comment> ChildComments { get; set; }
+        public Guid? ParentCommentGuid { get; set; }
+        public Comment? ParentComment { get; set; }
+        public IList<Comment>? ChildComments { get; set; }
 
         [Required]
         public string Content { get; set; }
 
         [DatabaseGenerated(DatabaseGeneratedOption.Computed)]
         public DateTime Published { get; set; }
-
+        
         [DatabaseGenerated(DatabaseGeneratedOption.Computed)]
         public DateTime Edited { get; set; }
     }

--- a/backend/Domain/Models/Comment.cs
+++ b/backend/Domain/Models/Comment.cs
@@ -16,10 +16,9 @@ namespace OpenData.Domain.Models
         public string UserMail { get; set; }
         public User User { get; set; }
 
-        [ForeignKey("ParentComment")]
-        public Guid? ParentCommentGuid { get; set; }
+        public Guid? ParentCommentUuid { get; set; }
         public Comment? ParentComment { get; set; }
-        public IList<Comment>? ChildComments { get; set; }
+        public IList<Comment> ChildComments { get; set; }
 
         [Required]
         public string Content { get; set; }

--- a/backend/Domain/Models/Comment.cs
+++ b/backend/Domain/Models/Comment.cs
@@ -16,10 +16,6 @@ namespace OpenData.Domain.Models
         public string UserMail { get; set; }
         public User User { get; set; }
 
-        public Guid? ParentCommentUuid { get; set; }
-        public Comment? ParentComment { get; set; }
-        public IList<Comment> ChildComments { get; set; }
-
         [Required]
         public string Content { get; set; }
 
@@ -28,5 +24,9 @@ namespace OpenData.Domain.Models
         
         [DatabaseGenerated(DatabaseGeneratedOption.Computed)]
         public DateTime Edited { get; set; }
+
+        public Guid? ParentCommentUuid { get; set; }
+        public Comment? ParentComment { get; set; }
+        public IList<Comment> ChildComments { get; set; }
     }
 }

--- a/backend/Domain/Models/ExperiencePost.cs
+++ b/backend/Domain/Models/ExperiencePost.cs
@@ -16,6 +16,7 @@ namespace OpenData.Domain.Models
 
 		public User LastEditedBy { get; set;}
 
+		public IList<ExperiencePostCommentMapping> Comments { get; set; }
 		public IList<ExperiencePostTagMapping> Tags { get; set; }
 
 		[DatabaseGenerated(DatabaseGeneratedOption.Computed)]

--- a/backend/Domain/Models/ExperiencePostCommentMapping.cs
+++ b/backend/Domain/Models/ExperiencePostCommentMapping.cs
@@ -4,14 +4,14 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace OpenData.Domain.Models
 {
-    public class MetadataCommentMapping
+    public class ExperiencePostCommentMapping
     {
         [ForeignKey("Comment")]
         public Guid CommentUuid { get; set; }
         public Comment Comment { get; set; }
-
-        [ForeignKey("Metadata")]
-        public Guid MetadataUuid { get; set; }
-        public Metadata Metadata { get; set; }
+        
+        [ForeignKey("ExperiencePost")]
+        public Guid ExperiencePostUuid { get; set; }
+        public ExperiencePost ExperiencePost { get; set; }
     }
 }

--- a/backend/Domain/Models/ExperiencePostTagMapping.cs
+++ b/backend/Domain/Models/ExperiencePostTagMapping.cs
@@ -9,7 +9,7 @@ namespace OpenData.Domain.Models
 
 		public Tag Tag { get; set; }
 
-		public Guid ExperiencePostGuid { get; set; }
+		public Guid ExperiencePostUuid { get; set; }
 
 		public ExperiencePost Post { get; set; }
 	}

--- a/backend/Domain/Models/Metadata.cs
+++ b/backend/Domain/Models/Metadata.cs
@@ -24,6 +24,8 @@ namespace OpenData.Domain.Models
 		public string MetadataTypeName { get; set; }
 		public MetadataType Type { get; set; }
 
+		public IList<MetadataCommentMapping> Comments { get; set; }
+
 		[ForeignKey("ExperiencePost")]
 		public Guid? ExperiencePostGuid { get; set; }
 		public ExperiencePost? ExperiencePost { get; set; }

--- a/backend/Domain/Models/MetadataCommentMapping.cs
+++ b/backend/Domain/Models/MetadataCommentMapping.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace OpenData.Domain.Models
+{
+    public class MetadataCommentMapping
+    {
+        [Key]
+        public Guid CommentUuid { get; set; }
+
+        [Key]
+        public Guid MetadataUuid { get; set; }
+    }
+}

--- a/backend/Domain/Repositories/ICommentRepository.cs
+++ b/backend/Domain/Repositories/ICommentRepository.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using System;
+
+using OpenData.Domain.Models;
+
+namespace OpenData.Domain.Repositories
+{
+    public interface ICommentRepository
+    {
+        Task AddRootCommentToMetadataAsync(Comment comment);
+        Task AddRootCommentToExperiencePostAsync(Comment comment);
+        Task ReplyToCommentAsync(Comment comment);
+        Task<IEnumerable<Comment>> FetchCommentsForMetadataAsync(Guid uuid);
+        Task<IEnumerable<Comment>> FetchCommentsForExperiencePostAsync(Guid uuid);
+    }
+}

--- a/backend/Domain/Repositories/ICommentRepository.cs
+++ b/backend/Domain/Repositories/ICommentRepository.cs
@@ -13,5 +13,6 @@ namespace OpenData.Domain.Repositories
         Task ReplyToCommentAsync(Comment comment);
         Task<IEnumerable<Comment>> FetchCommentsForMetadataAsync(Guid metadataUuid);
         Task<IEnumerable<Comment>> FetchCommentsForExperiencePostAsync(Guid experiencePostUuid);
+        Task<IEnumerable<Comment>> FetchChildComments(Guid commentUuid);
     }
 }

--- a/backend/Domain/Repositories/ICommentRepository.cs
+++ b/backend/Domain/Repositories/ICommentRepository.cs
@@ -8,10 +8,10 @@ namespace OpenData.Domain.Repositories
 {
     public interface ICommentRepository
     {
-        Task AddRootCommentToMetadataAsync(Comment comment);
-        Task AddRootCommentToExperiencePostAsync(Comment comment);
+        Task AddRootCommentToMetadataAsync(Guid metadataUiid, Comment comment);
+        Task AddRootCommentToExperiencePostAsync(Guid experiencePostUiid, Comment comment);
         Task ReplyToCommentAsync(Comment comment);
-        Task<IEnumerable<Comment>> FetchCommentsForMetadataAsync(Guid uuid);
-        Task<IEnumerable<Comment>> FetchCommentsForExperiencePostAsync(Guid uuid);
+        Task<IEnumerable<Comment>> FetchCommentsForMetadataAsync(Guid metadataUuid);
+        Task<IEnumerable<Comment>> FetchCommentsForExperiencePostAsync(Guid experiencePostUuid);
     }
 }

--- a/backend/Domain/Repositories/IMetadataRepository.cs
+++ b/backend/Domain/Repositories/IMetadataRepository.cs
@@ -11,7 +11,7 @@ namespace OpenData.Domain.Repositories
         Task<IEnumerable<Metadata>> ListAsync();
         Task<Metadata> GetByUuidAsync(Guid uuid);
         Task AddAsync(Metadata metadata);
-        Task<Comment> AddCommentAsync(Comment comment);
-        Task<IEnumerable<Comment>> FetchCommentsAsync(Guid uuid);
+        Task<<CComment> AddCommentAsync((CComment comment);
+        Task<IEnumerable<<CComment>> FetchCommentsAsync(Guid uuid);
     }
 }

--- a/backend/Domain/Repositories/IMetadataRepository.cs
+++ b/backend/Domain/Repositories/IMetadataRepository.cs
@@ -8,8 +8,10 @@ namespace OpenData.Domain.Repositories
 {
     public interface IMetadataRepository
     {
-         Task<IEnumerable<Metadata>> ListAsync();
-         Task<Metadata> GetByUuidAsync(Guid uuid);
-         Task AddAsync(Metadata metadata);
+        Task<IEnumerable<Metadata>> ListAsync();
+        Task<Metadata> GetByUuidAsync(Guid uuid);
+        Task AddAsync(Metadata metadata);
+        Task AddCommentAsync(Comment comment);
+        Task<IEnumerable<Comment>> FetchCommentsAsync(string uuid);
     }
 }

--- a/backend/Domain/Repositories/IMetadataRepository.cs
+++ b/backend/Domain/Repositories/IMetadataRepository.cs
@@ -11,7 +11,5 @@ namespace OpenData.Domain.Repositories
         Task<IEnumerable<Metadata>> ListAsync();
         Task<Metadata> GetByUuidAsync(Guid uuid);
         Task AddAsync(Metadata metadata);
-        Task<<CComment> AddCommentAsync((CComment comment);
-        Task<IEnumerable<<CComment>> FetchCommentsAsync(Guid uuid);
     }
 }

--- a/backend/Domain/Repositories/IMetadataRepository.cs
+++ b/backend/Domain/Repositories/IMetadataRepository.cs
@@ -11,7 +11,7 @@ namespace OpenData.Domain.Repositories
         Task<IEnumerable<Metadata>> ListAsync();
         Task<Metadata> GetByUuidAsync(Guid uuid);
         Task AddAsync(Metadata metadata);
-        Task AddCommentAsync(Comment comment);
-        Task<IEnumerable<Comment>> FetchCommentsAsync(string uuid);
+        Task<Comment> AddCommentAsync(Comment comment);
+        Task<IEnumerable<Comment>> FetchCommentsAsync(Guid uuid);
     }
 }

--- a/backend/Domain/Repositories/IMunicipalityRepository.cs
+++ b/backend/Domain/Repositories/IMunicipalityRepository.cs
@@ -9,6 +9,5 @@ namespace OpenData.Domain.Repositories
         Task<IEnumerable<Municipality>> ListAsync();
         Task<Municipality> FetchByName(string name);
         Task<Municipality> GetMunicipalityByDomainAsync(string domain);
-        Task<Comment> AddCommentAsync(Comment comment)
     }
 }

--- a/backend/Domain/Repositories/IMunicipalityRepository.cs
+++ b/backend/Domain/Repositories/IMunicipalityRepository.cs
@@ -6,8 +6,9 @@ namespace OpenData.Domain.Repositories
 {
     public interface IMunicipalityRepository
     {
-         Task<IEnumerable<Municipality>> ListAsync();
+        Task<IEnumerable<Municipality>> ListAsync();
         Task<Municipality> FetchByName(string name);
         Task<Municipality> GetMunicipalityByDomainAsync(string domain);
+        Task<Comment> AddCommentAsync(Comment comment)
     }
 }

--- a/backend/Domain/Services/ICommentService.cs
+++ b/backend/Domain/Services/ICommentService.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using OpenData.Domain.Models;
+
+namespace OpenData.Domain.Services
+{
+    public interface ICommentService
+    {
+        Task AddRootCommentToMetadataAsync(Guid MetadataUiid, Comment comment);
+        Task AddRootCommentToExperiencePostAsync(Guid ExperiencePostUiid, Comment comment);
+        Task ReplyToCommentAsync(Comment comment);
+        Task<IEnumerable<Comment>> FetchCommentsForMetadataAsync(Guid metadataGuid);
+        Task<IEnumerable<Comment>> FetchCommentsForExperiencePostAsync(Guid experiencePostGuid);
+    }
+}

--- a/backend/Domain/Services/ICommentService.cs
+++ b/backend/Domain/Services/ICommentService.cs
@@ -13,5 +13,6 @@ namespace OpenData.Domain.Services
         Task ReplyToCommentAsync(Comment comment);
         Task<IEnumerable<Comment>> FetchCommentsForMetadataAsync(Guid metadataUuid);
         Task<IEnumerable<Comment>> FetchCommentsForExperiencePostAsync(Guid experiencePostUuid);
+        Task<IEnumerable<Comment>> FetchChildComments(Guid commentUuid);
     }
 }

--- a/backend/Domain/Services/ICommentService.cs
+++ b/backend/Domain/Services/ICommentService.cs
@@ -8,10 +8,10 @@ namespace OpenData.Domain.Services
 {
     public interface ICommentService
     {
-        Task AddRootCommentToMetadataAsync(Guid MetadataUiid, Comment comment);
-        Task AddRootCommentToExperiencePostAsync(Guid ExperiencePostUiid, Comment comment);
+        Task AddRootCommentToMetadataAsync(Guid metadataUiid, Comment comment);
+        Task AddRootCommentToExperiencePostAsync(Guid experiencePostUiid, Comment comment);
         Task ReplyToCommentAsync(Comment comment);
-        Task<IEnumerable<Comment>> FetchCommentsForMetadataAsync(Guid metadataGuid);
-        Task<IEnumerable<Comment>> FetchCommentsForExperiencePostAsync(Guid experiencePostGuid);
+        Task<IEnumerable<Comment>> FetchCommentsForMetadataAsync(Guid metadataUuid);
+        Task<IEnumerable<Comment>> FetchCommentsForExperiencePostAsync(Guid experiencePostUuid);
     }
 }

--- a/backend/Domain/Services/IMetadataService.cs
+++ b/backend/Domain/Services/IMetadataService.cs
@@ -12,7 +12,7 @@ namespace OpenData.Domain.Services
         Task<IEnumerable<Metadata>> ListAsync();
         Task<Metadata> GetByUuidAsync(Guid uuid);
         Task<SaveMetadataResponse> SaveAsync(Metadata metadata);
-        Task AddCommentAsync(Comment comment);
-        Task<IEnumerable<Comment>> FetchCommentsAsync(string uuid);
+        Task<Comment> AddCommentAsync(Comment comment);
+        Task<IEnumerable<Comment>> FetchCommentsAsync(Guid uuid);
     }
 }

--- a/backend/Domain/Services/IMetadataService.cs
+++ b/backend/Domain/Services/IMetadataService.cs
@@ -12,7 +12,5 @@ namespace OpenData.Domain.Services
         Task<IEnumerable<Metadata>> ListAsync();
         Task<Metadata> GetByUuidAsync(Guid uuid);
         Task<SaveMetadataResponse> SaveAsync(Metadata metadata);
-        Task<Comment> AddCommentAsync(Comment comment);
-        Task<IEnumerable<Comment>> FetchCommentsAsync(Guid uuid);
     }
 }

--- a/backend/Domain/Services/IMetadataService.cs
+++ b/backend/Domain/Services/IMetadataService.cs
@@ -9,8 +9,10 @@ namespace OpenData.Domain.Services
 {
     public interface IMetadataService
     {
-         Task<IEnumerable<Metadata>> ListAsync();
-         Task<Metadata> GetByUuidAsync(Guid uuid);
-         Task<SaveMetadataResponse> SaveAsync(Metadata metadata);
+        Task<IEnumerable<Metadata>> ListAsync();
+        Task<Metadata> GetByUuidAsync(Guid uuid);
+        Task<SaveMetadataResponse> SaveAsync(Metadata metadata);
+        Task AddCommentAsync(Comment comment);
+        Task<IEnumerable<Comment>> FetchCommentsAsync(string uuid);
     }
 }

--- a/backend/Mapping/ModelToResourceProfile.cs
+++ b/backend/Mapping/ModelToResourceProfile.cs
@@ -32,7 +32,7 @@ namespace OpenData.Mapping
             CreateMap<User, PrivateSafeUserResource>();
             CreateMap<User, SafeUserResource>();
 
-            CreateMap<NewCommentResource, Comment>();
+            CreateMap<NewCommentResource,  CComment>();
         }
     }
 }

--- a/backend/Mapping/ModelToResourceProfile.cs
+++ b/backend/Mapping/ModelToResourceProfile.cs
@@ -31,6 +31,8 @@ namespace OpenData.Mapping
             CreateMap<NewUserResource, User>();
             CreateMap<User, PrivateSafeUserResource>();
             CreateMap<User, SafeUserResource>();
+
+            CreateMap<NewCommentResource, Comment>();
         }
     }
 }

--- a/backend/Mapping/ModelToResourceProfile.cs
+++ b/backend/Mapping/ModelToResourceProfile.cs
@@ -32,7 +32,8 @@ namespace OpenData.Mapping
             CreateMap<User, PrivateSafeUserResource>();
             CreateMap<User, SafeUserResource>();
 
-            CreateMap<NewCommentResource,  CComment>();
+            CreateMap<NewCommentResource,  Comment>();
+            CreateMap<Comment,  CommentResource>();
         }
     }
 }

--- a/backend/Persistence/Contexts/AppDbContext.cs
+++ b/backend/Persistence/Contexts/AppDbContext.cs
@@ -18,6 +18,7 @@ namespace OpenData.Persistence.Contexts
         public DbSet<MetadataType> MetadataTypes { get; set; }
         public DbSet<Metadata> Metadata { get; set; }
         public DbSet<Tag> Tags { get; set; }
+        public DbSet<Comment> Comment { get; set; }
 
         public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
 
@@ -117,6 +118,12 @@ namespace OpenData.Persistence.Contexts
             builder.Entity<ExperiencePostTagMapping>().HasKey(p => new {p.TagName, p.ExperiencePostGuid});
             builder.Entity<ExperiencePostTagMapping>().HasOne(p => p.Post).WithMany(p => p.Tags).HasForeignKey(p => p.ExperiencePostGuid);
             builder.Entity<ExperiencePostTagMapping>().HasOne(p => p.Tag).WithMany().HasForeignKey(p => p.TagName);
+
+            builder.Entity<Comment>().ToTable("Comment");
+            builder.Entity<Comment>().HasKey(p => p.Uuid);
+            builder.Entity<Comment>().Property(p => p.Content).IsRequired();
+            builder.Entity<Comment>().Property(p => p.UserMail).IsRequired();
+            builder.Entity<Comment>().Property(p => p.MetadataUuid).IsRequired();
         }
     }
 }

--- a/backend/Persistence/Contexts/AppDbContext.cs
+++ b/backend/Persistence/Contexts/AppDbContext.cs
@@ -19,6 +19,8 @@ namespace OpenData.Persistence.Contexts
         public DbSet<Metadata> Metadata { get; set; }
         public DbSet<Tag> Tags { get; set; }
         public DbSet<Comment> Comments { get; set; }
+        public DbSet<MetadataCommentMapping> MetadataCommentMappings { get; set; }
+        public DbSet<ExperiencePostCommentMapping> ExperiencePostCommentMappings { get; set; }
 
         public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
 
@@ -87,14 +89,27 @@ namespace OpenData.Persistence.Contexts
             builder.Entity<Metadata>().HasOne(p => p.ExperiencePost);
             builder.Entity<Metadata>().Property( p => p.ReleaseState).IsRequired();
 
-            builder.Entity<Comment>().ToTable("MetadataComments");
+            builder.Entity<Comment>().ToTable("Comment");
             builder.Entity<Comment>().HasKey(p => p.Uuid);
             builder.Entity<Comment>().Property(p => p.Content).IsRequired();
             builder.Entity<Comment>().Property(p => p.UserMail).IsRequired();
-            builder.Entity<Comment>().Property(p => p.MetadataUuid).IsRequired();
             builder.Entity<Comment>().Property(p => p.Published).IsRequired();
             builder.Entity<Comment>().Property(p => p.Edited).IsRequired();
-            builder.Entity<Comment>().HasMany(p => p.ChildComments).WithOne(p => p.ParentComment);
+            builder.Entity<Comment>()
+                .HasMany(p => p.ChildComments)
+                .WithOne(p => p.ParentComment)
+                .HasForeignKey(p => p.ParentCommentUuid);
+
+            builder.Entity<MetadataCommentMapping>().HasKey(p => new { p.MetadataUuid, p.CommentUuid });
+            builder.Entity<MetadataCommentMapping>()
+                .HasOne(p => p.Metadata)
+                .WithMany(p => p.Comments)
+                .HasForeignKey(p => p.MetadataUuid);
+            builder.Entity<ExperiencePostCommentMapping>().HasKey(p => new { p.ExperiencePostUuid, p.CommentUuid });
+            builder.Entity<ExperiencePostCommentMapping>()
+                .HasOne(p => p.ExperiencePost)
+                .WithMany(p => p.Comments)
+                .HasForeignKey(p => p.ExperiencePostUuid);
 
             builder.Entity<Tag>().ToTable("Tags");
             builder.Entity<Tag>().HasKey(p => p.Name);
@@ -124,8 +139,8 @@ namespace OpenData.Persistence.Contexts
             builder.Entity<ExperiencePost>().Property(p => p.Modified).IsRequired();
 
             builder.Entity<ExperiencePostTagMapping>().ToTable("ExperiencePostTagMapping");
-            builder.Entity<ExperiencePostTagMapping>().HasKey(p => new {p.TagName, p.ExperiencePostGuid});
-            builder.Entity<ExperiencePostTagMapping>().HasOne(p => p.Post).WithMany(p => p.Tags).HasForeignKey(p => p.ExperiencePostGuid);
+            builder.Entity<ExperiencePostTagMapping>().HasKey(p => new {p.TagName, p.ExperiencePostUuid});
+            builder.Entity<ExperiencePostTagMapping>().HasOne(p => p.Post).WithMany(p => p.Tags).HasForeignKey(p => p.ExperiencePostUuid);
             builder.Entity<ExperiencePostTagMapping>().HasOne(p => p.Tag).WithMany().HasForeignKey(p => p.TagName);
         }
     }

--- a/backend/Persistence/Contexts/AppDbContext.cs
+++ b/backend/Persistence/Contexts/AppDbContext.cs
@@ -18,7 +18,7 @@ namespace OpenData.Persistence.Contexts
         public DbSet<MetadataType> MetadataTypes { get; set; }
         public DbSet<Metadata> Metadata { get; set; }
         public DbSet<Tag> Tags { get; set; }
-        public DbSet<Comment> Comment { get; set; }
+        public DbSet<Comment> Comments { get; set; }
 
         public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
 
@@ -87,6 +87,15 @@ namespace OpenData.Persistence.Contexts
             builder.Entity<Metadata>().HasOne(p => p.ExperiencePost);
             builder.Entity<Metadata>().Property( p => p.ReleaseState).IsRequired();
 
+            builder.Entity<Comment>().ToTable("Comments");
+            builder.Entity<Comment>().HasKey(p => p.Uuid);
+            builder.Entity<Comment>().Property(p => p.Content).IsRequired();
+            builder.Entity<Comment>().Property(p => p.UserMail).IsRequired();
+            builder.Entity<Comment>().Property(p => p.MetadataUuid).IsRequired();
+            builder.Entity<Comment>().Property(p => p.Published).IsRequired();
+            builder.Entity<Comment>().Property(p => p.Edited).IsRequired();
+            builder.Entity<Comment>().HasMany(p => p.ChildComments).WithOne(p => p.ParentComment);
+
             builder.Entity<Tag>().ToTable("Tags");
             builder.Entity<Tag>().HasKey(p => p.Name);
 
@@ -118,12 +127,6 @@ namespace OpenData.Persistence.Contexts
             builder.Entity<ExperiencePostTagMapping>().HasKey(p => new {p.TagName, p.ExperiencePostGuid});
             builder.Entity<ExperiencePostTagMapping>().HasOne(p => p.Post).WithMany(p => p.Tags).HasForeignKey(p => p.ExperiencePostGuid);
             builder.Entity<ExperiencePostTagMapping>().HasOne(p => p.Tag).WithMany().HasForeignKey(p => p.TagName);
-
-            builder.Entity<Comment>().ToTable("Comment");
-            builder.Entity<Comment>().HasKey(p => p.Uuid);
-            builder.Entity<Comment>().Property(p => p.Content).IsRequired();
-            builder.Entity<Comment>().Property(p => p.UserMail).IsRequired();
-            builder.Entity<Comment>().Property(p => p.MetadataUuid).IsRequired();
         }
     }
 }

--- a/backend/Persistence/Contexts/AppDbContext.cs
+++ b/backend/Persistence/Contexts/AppDbContext.cs
@@ -87,7 +87,7 @@ namespace OpenData.Persistence.Contexts
             builder.Entity<Metadata>().HasOne(p => p.ExperiencePost);
             builder.Entity<Metadata>().Property( p => p.ReleaseState).IsRequired();
 
-            builder.Entity<Comment>().ToTable("Comments");
+            builder.Entity<Comment>().ToTable("MetadataComments");
             builder.Entity<Comment>().HasKey(p => p.Uuid);
             builder.Entity<Comment>().Property(p => p.Content).IsRequired();
             builder.Entity<Comment>().Property(p => p.UserMail).IsRequired();

--- a/backend/Persistence/Repositories/CommentRepository.cs
+++ b/backend/Persistence/Repositories/CommentRepository.cs
@@ -56,10 +56,10 @@ namespace OpenData.Persistence.Repositories
             return await _context
                 .ExperiencePostCommentMappings
                 .Include(m => m.Comment)
-                .ThenInclude(m => m.ChildComments)
-                .ThenInclude(m => m.ChildComments)
-                .ThenInclude(m => m.ChildComments)
-                .ThenInclude(m => m.ChildComments)
+                .ThenInclude(c => c.ChildComments)
+                .ThenInclude(c => c.ChildComments)
+                .ThenInclude(c => c.ChildComments)
+                .ThenInclude(c => c.ChildComments)
                 .Where(m => m.ExperiencePostUuid == experiencePostUuid)
                 .Select((m) => m.Comment)
                 .ToListAsync();
@@ -70,15 +70,26 @@ namespace OpenData.Persistence.Repositories
             return await _context
                 .MetadataCommentMappings
                 .Include(m => m.Comment)
-                .ThenInclude(m => m.ChildComments)
-                .ThenInclude(m => m.ChildComments)
-                .ThenInclude(m => m.ChildComments)
-                .ThenInclude(m => m.ChildComments)
+                .ThenInclude(c => c.ChildComments)
+                .ThenInclude(c => c.ChildComments)
+                .ThenInclude(c => c.ChildComments)
+                .ThenInclude(c => c.ChildComments)
                 .Where(m => m.MetadataUuid == metadataUuid)
                 .Select((m) => m.Comment)
                 .ToListAsync();
         }
 
-        
+        public async Task<IEnumerable<Comment>> FetchChildComments(Guid commentUuid)
+        {
+            return await _context
+                .Comments
+                .Include(c => c.ChildComments)
+                .ThenInclude(c => c.ChildComments)
+                .ThenInclude(c => c.ChildComments)
+                .ThenInclude(c => c.ChildComments)
+                .ThenInclude(c => c.ChildComments)
+                .Where(c => c.Uuid == commentUuid)
+                .ToListAsync();
+        }
     }
 }

--- a/backend/Persistence/Repositories/CommentRepository.cs
+++ b/backend/Persistence/Repositories/CommentRepository.cs
@@ -6,14 +6,79 @@ using OpenData.Domain.Repositories;
 using OpenData.Persistence.Contexts;
 using System.Web;
 using System;
+using System.Linq;
 
 namespace OpenData.Persistence.Repositories
 {
     public class CommentRepository : BaseRepository, ICommentRepository
     {
-        public CommentRepository(AppDbContext context) : base(context)
-        {
+        public CommentRepository(AppDbContext context) : base(context) { }
 
+
+        private async Task<Comment> AddRootComment(Comment comment)
+        {
+            await _context.Comments.AddAsync(comment);
+            return await _context.Comments.SingleOrDefaultAsync(c => c.Uuid == comment.Uuid);
         }
+
+        public async Task AddRootCommentToExperiencePostAsync(Guid experiencePostUiid, Comment comment)
+        {
+            await AddRootComment(comment);
+
+            var experiencePostCommentMapping = new ExperiencePostCommentMapping();
+            experiencePostCommentMapping.CommentUuid = comment.Uuid;
+            experiencePostCommentMapping.ExperiencePostUuid = experiencePostUiid;
+            await _context.ExperiencePostCommentMappings.AddAsync(experiencePostCommentMapping);
+
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task AddRootCommentToMetadataAsync(Guid metadataUiid, Comment comment)
+        {
+            await AddRootComment(comment);
+
+            var metadataCommentMapping = new MetadataCommentMapping();
+            metadataCommentMapping.CommentUuid = comment.Uuid;
+            metadataCommentMapping.MetadataUuid = metadataUiid;
+            await _context.MetadataCommentMappings.AddAsync(metadataCommentMapping);
+
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task ReplyToCommentAsync(Comment comment)
+        {
+            await AddRootComment(comment);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task<IEnumerable<Comment>> FetchCommentsForExperiencePostAsync(Guid experiencePostUuid)
+        {
+            return await _context
+                .ExperiencePostCommentMappings
+                .Include(m => m.Comment)
+                .ThenInclude(m => m.ChildComments)
+                .ThenInclude(m => m.ChildComments)
+                .ThenInclude(m => m.ChildComments)
+                .ThenInclude(m => m.ChildComments)
+                .Where(m => m.ExperiencePostUuid == experiencePostUuid)
+                .Select((m) => m.Comment)
+                .ToListAsync();
+        }
+
+        public async Task<IEnumerable<Comment>> FetchCommentsForMetadataAsync(Guid metadataUuid)
+        {
+            return await _context
+                .MetadataCommentMappings
+                .Include(m => m.Comment)
+                .ThenInclude(m => m.ChildComments)
+                .ThenInclude(m => m.ChildComments)
+                .ThenInclude(m => m.ChildComments)
+                .ThenInclude(m => m.ChildComments)
+                .Where(m => m.MetadataUuid == metadataUuid)
+                .Select((m) => m.Comment)
+                .ToListAsync();
+        }
+
+        
     }
 }

--- a/backend/Persistence/Repositories/CommentRepository.cs
+++ b/backend/Persistence/Repositories/CommentRepository.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using OpenData.Domain.Models;
+using OpenData.Domain.Repositories;
+using OpenData.Persistence.Contexts;
+using System.Web;
+using System;
+
+namespace OpenData.Persistence.Repositories
+{
+    public class CommentRepository : BaseRepository, ICommentRepository
+    {
+        public CommentRepository(AppDbContext context) : base(context)
+        {
+
+        }
+    }
+}

--- a/backend/Persistence/Repositories/MetadataRepository.cs
+++ b/backend/Persistence/Repositories/MetadataRepository.cs
@@ -6,6 +6,7 @@ using OpenData.Domain.Repositories;
 using OpenData.Persistence.Contexts;
 using System.Web;
 using System;
+using System.Linq;
 
 namespace OpenData.Persistence.Repositories
 {
@@ -27,6 +28,16 @@ namespace OpenData.Persistence.Repositories
 
         public async Task AddAsync(Metadata metadata) {
             await _context.Metadata.AddAsync(metadata);
+        }
+
+        public async Task AddCommentAsync(Comment comment)
+        {
+            await _context.Comment.AddAsync(comment);
+        }
+
+        public async Task<IEnumerable<Comment>> FetchCommentsAsync(string uuid)
+        {
+            return await _context.Comment.Where(p => p.MetadataUuid == uuid).OrderBy(p => p.Published).ToListAsync();
         }
     }
 }

--- a/backend/Persistence/Repositories/MetadataRepository.cs
+++ b/backend/Persistence/Repositories/MetadataRepository.cs
@@ -30,14 +30,15 @@ namespace OpenData.Persistence.Repositories
             await _context.Metadata.AddAsync(metadata);
         }
 
-        public async Task AddCommentAsync(Comment comment)
+        public async Task<Comment> AddCommentAsync(Comment comment)
         {
-            await _context.Comment.AddAsync(comment);
+            await _context.Comments.AddAsync(comment);
+            return await _context.Comments.SingleOrDefaultAsync(c => c.Uuid == comment.Uuid);
         }
 
-        public async Task<IEnumerable<Comment>> FetchCommentsAsync(string uuid)
+        public async Task<IEnumerable<Comment>> FetchCommentsAsync(Guid uuid)
         {
-            return await _context.Comment.Where(p => p.MetadataUuid == uuid).OrderBy(p => p.Published).ToListAsync();
+            return await _context.Comments.Where(p => p.MetadataUuid == uuid).OrderBy(p => p.Published).ToListAsync();
         }
     }
 }

--- a/backend/Persistence/Repositories/MetadataRepository.cs
+++ b/backend/Persistence/Repositories/MetadataRepository.cs
@@ -6,7 +6,6 @@ using OpenData.Domain.Repositories;
 using OpenData.Persistence.Contexts;
 using System.Web;
 using System;
-using System.Linq;
 
 namespace OpenData.Persistence.Repositories
 {

--- a/backend/Persistence/Repositories/MetadataRepository.cs
+++ b/backend/Persistence/Repositories/MetadataRepository.cs
@@ -29,17 +29,5 @@ namespace OpenData.Persistence.Repositories
         public async Task AddAsync(Metadata metadata) {
             await _context.Metadata.AddAsync(metadata);
         }
-
-        public async Task<Comment> AddCommentAsync(Comment comment)
-        {
-            await _context.Comments.AddAsync(comment);
-            await _context.SaveChangesAsync();
-            return await _context.Comments.SingleOrDefaultAsync(c => c.Uuid == comment.Uuid);
-        }
-
-        public async Task<IEnumerable<Comment>> FetchCommentsAsync(Guid uuid)
-        {
-            return await _context.Comments.Where(p => p.MetadataUuid == uuid).OrderBy(p => p.Published).ToListAsync();
-        }
     }
 }

--- a/backend/Persistence/Repositories/MetadataRepository.cs
+++ b/backend/Persistence/Repositories/MetadataRepository.cs
@@ -33,6 +33,7 @@ namespace OpenData.Persistence.Repositories
         public async Task<Comment> AddCommentAsync(Comment comment)
         {
             await _context.Comments.AddAsync(comment);
+            await _context.SaveChangesAsync();
             return await _context.Comments.SingleOrDefaultAsync(c => c.Uuid == comment.Uuid);
         }
 

--- a/backend/Resources/CommentResource.cs
+++ b/backend/Resources/CommentResource.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace OpenData.Resources
+{
+    public class CommentResource
+    {
+        
+    }
+}

--- a/backend/Resources/CommentResource.cs
+++ b/backend/Resources/CommentResource.cs
@@ -11,12 +11,12 @@ namespace OpenData.Resources
         public string UserMail { get; set; }
         public User User { get; set; }
 
-        public Guid ParentCommentUuid { get; set; }
-        public IList<CommentResource> ChildComments { get; set; }
-
         public string Content { get; set; }
 
         public DateTime Published { get; set; }
         public DateTime Edited { get; set; }
+
+        public Guid ParentCommentUuid { get; set; }
+        public IList<CommentResource> ChildComments { get; set; }
     }
 }

--- a/backend/Resources/CommentResource.cs
+++ b/backend/Resources/CommentResource.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace OpenData.Resources
-{
-    public class CommentResource
-    {
-        
-    }
-}

--- a/backend/Resources/CommentResource.cs
+++ b/backend/Resources/CommentResource.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using OpenData.Domain.Models;
+
+namespace OpenData.Resources
+{
+    public class CommentResource
+    {
+        public Guid Uuid { get; set; }
+
+        public string UserMail { get; set; }
+        public User User { get; set; }
+
+        public Guid ParentCommentUuid { get; set; }
+        public IList<CommentResource> ChildComments { get; set; }
+
+        public string Content { get; set; }
+
+        public DateTime Published { get; set; }
+        public DateTime Edited { get; set; }
+    }
+}

--- a/backend/Resources/NewCommentResource.cs
+++ b/backend/Resources/NewCommentResource.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using OpenData.Domain.Models;
+
+namespace OpenData.Resources
+{
+    public class NewCommentResource
+    {
+        [Required]
+        public string Content { get; set; }
+        public Guid ParentCommentGuid { get; set; }
+    }
+}

--- a/backend/Services/CommentService.cs
+++ b/backend/Services/CommentService.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using OpenData.Domain.Models;
 using OpenData.Domain.Repositories;
+using OpenData.Domain.Services;
 
 namespace OpenData.Services
 {
@@ -10,6 +14,31 @@ namespace OpenData.Services
         public CommentService(ICommentRepository commentRepository)
         {
             this.commentRepository = commentRepository;
+        }
+
+        public async Task AddRootCommentToExperiencePostAsync(Guid experiencePostUiid, Comment comment)
+        {
+            await commentRepository.AddRootCommentToExperiencePostAsync(experiencePostUiid, comment);
+        }
+
+        public async Task AddRootCommentToMetadataAsync(Guid metadataUiid, Comment comment)
+        {
+            await commentRepository.AddRootCommentToMetadataAsync(metadataUiid, comment);
+        }
+
+        public async Task<IEnumerable<Comment>> FetchCommentsForExperiencePostAsync(Guid experiencePostGuid)
+        {
+            return await commentRepository.FetchCommentsForExperiencePostAsync(experiencePostGuid);
+        }
+
+        public async Task<IEnumerable<Comment>> FetchCommentsForMetadataAsync(Guid metadataGuid)
+        {
+            return await commentRepository.FetchCommentsForMetadataAsync(metadataGuid);
+        }
+
+        public async Task ReplyToCommentAsync(Comment comment)
+        {
+            await commentRepository.ReplyToCommentAsync(comment);
         }
     }
 }

--- a/backend/Services/CommentService.cs
+++ b/backend/Services/CommentService.cs
@@ -26,6 +26,11 @@ namespace OpenData.Services
             await commentRepository.AddRootCommentToMetadataAsync(metadataUiid, comment);
         }
 
+        public async Task<IEnumerable<Comment>> FetchChildComments(Guid commentUuid)
+        {
+            return await commentRepository.FetchChildComments(commentUuid);
+        }
+
         public async Task<IEnumerable<Comment>> FetchCommentsForExperiencePostAsync(Guid experiencePostGuid)
         {
             return await commentRepository.FetchCommentsForExperiencePostAsync(experiencePostGuid);

--- a/backend/Services/CommentService.cs
+++ b/backend/Services/CommentService.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using OpenData.Domain.Repositories;
+
+namespace OpenData.Services
+{
+    public class CommentService : ICommentService
+    {
+        private readonly ICommentRepository commentRepository;
+
+        public CommentService(ICommentRepository commentRepository)
+        {
+            this.commentRepository = commentRepository;
+        }
+    }
+}

--- a/backend/Services/MetadataService.cs
+++ b/backend/Services/MetadataService.cs
@@ -40,14 +40,5 @@ namespace OpenData.Services
                 return new SaveMetadataResponse($"An error occurred when saving the category: {ex.Message}");
             }
         }
-
-        public async Task<<CComment> AddCommentAsync((CComment comment) {
-            return await _metadataRepository.AddCommentAsync(comment);
-        }
-
-        public async Task<IEnumerable<<CComment>> FetchCommentsAsync(Guid uuid)
-        {
-            return await _metadataRepository.FetchCommentsAsync(uuid);
-        }
     }
 }

--- a/backend/Services/MetadataService.cs
+++ b/backend/Services/MetadataService.cs
@@ -41,11 +41,11 @@ namespace OpenData.Services
             }
         }
 
-        public async Task<Comment> AddCommentAsync(Comment comment) {
+        public async Task<<CComment> AddCommentAsync((CComment comment) {
             return await _metadataRepository.AddCommentAsync(comment);
         }
 
-        public async Task<IEnumerable<Comment>> FetchCommentsAsync(Guid uuid)
+        public async Task<IEnumerable<<CComment>> FetchCommentsAsync(Guid uuid)
         {
             return await _metadataRepository.FetchCommentsAsync(uuid);
         }

--- a/backend/Services/MetadataService.cs
+++ b/backend/Services/MetadataService.cs
@@ -40,5 +40,14 @@ namespace OpenData.Services
                 return new SaveMetadataResponse($"An error occurred when saving the category: {ex.Message}");
             }
         }
+
+        public async Task AddCommentAsync(Comment comment) {
+            await _metadataRepository.AddCommentAsync(comment);
+        }
+
+        public async Task<IEnumerable<Comment>> FetchCommentsAsync(string uuid)
+        {
+            return await _metadataRepository.FetchCommentsAsync(uuid);
+        }
     }
 }

--- a/backend/Services/MetadataService.cs
+++ b/backend/Services/MetadataService.cs
@@ -41,11 +41,11 @@ namespace OpenData.Services
             }
         }
 
-        public async Task AddCommentAsync(Comment comment) {
-            await _metadataRepository.AddCommentAsync(comment);
+        public async Task<Comment> AddCommentAsync(Comment comment) {
+            return await _metadataRepository.AddCommentAsync(comment);
         }
 
-        public async Task<IEnumerable<Comment>> FetchCommentsAsync(string uuid)
+        public async Task<IEnumerable<Comment>> FetchCommentsAsync(Guid uuid)
         {
             return await _metadataRepository.FetchCommentsAsync(uuid);
         }

--- a/backend/Startup.cs
+++ b/backend/Startup.cs
@@ -89,6 +89,9 @@ namespace OpenData
 
             services.AddScoped<ISecurityService, SecurityService>();
 
+            services.AddScoped<ICommentService, CommentService>();
+            services.AddScoped<ICommentRepository, CommentRepository>();
+
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
             services.AddAuthorization();


### PR DESCRIPTION
Current maximum supported depth is 5 (including root level) for fetching comments and it's child comments. We may wanna extend this. Think the JSON parser supports up to 32 in depth. 

It is technically possible to reply to the leaf node comments, but one would be unable to fetch this level. We may wanna do something about this, or just enforce it client side by denying replying to level 5.