### PR TITLE
Removed default props

### DIFF
--- a/frontend/src/pages/Inspection/MetaData.jsx
+++ b/frontend/src/pages/Inspection/MetaData.jsx
@@ -91,17 +91,13 @@ export const MetaData = (props) => {
   );
 };
 
-MetaData.defaultTypes = {
-  uuid: '',
-};
-
 MetaData.propTypes = {
   data: PropTypes.shape({
     municipalityName: PropTypes.string.isRequired,
     formatName: PropTypes.string.isRequired,
     metadataTypeName: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
-    experiencePostGuid: PropTypes.string.isRequired,
+    experiencePostGuid: PropTypes.string,
     uuid: PropTypes.string,
   }).isRequired,
   description: PropTypes.string.isRequired,


### PR DESCRIPTION
Removed prop types errors from experiencePostGuid being required. It got solved by removing the isRequired and defaultprops. didn't seem to exist a way to define default props for object properties without eslint complaining.