### PR TITLE
Add authentication support to swagger

### DIFF
--- a/backend/Filters/AddAuthHeaderOperationFilter.cs
+++ b/backend/Filters/AddAuthHeaderOperationFilter.cs
@@ -1,0 +1,57 @@
+using Swashbuckle.AspNetCore.Swagger;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+using Microsoft.OpenApi.Services;
+using Microsoft.OpenApi.Models;
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+
+namespace OpenData.Filters {
+	public class AddAuthHeaderOperationFilter : IOperationFilter
+    {
+        private readonly IHttpContextAccessor httpContextAccessor;
+
+        public AddAuthHeaderOperationFilter(IHttpContextAccessor httpContextAccessor)
+        {
+            this.httpContextAccessor = httpContextAccessor;
+        }
+
+        public void Apply(OpenApiOperation operation, OperationFilterContext context)
+        {
+            var filterDescriptor = context.ApiDescription.ActionDescriptor.FilterDescriptors;
+            var isAuthorized = filterDescriptor.Select(filterInfo => filterInfo.Filter).Any(filter => filter is AuthorizeFilter);
+            var allowAnonymous = filterDescriptor.Select(filterInfo => filterInfo.Filter).Any(filter => filter is IAllowAnonymousFilter);
+
+            if (isAuthorized && !allowAnonymous)
+            {
+                if (operation.Parameters == null)
+                    operation.Parameters = new List<IParameter>();
+
+                operation.Parameters.Add(new NonBodyParameter
+                {
+                    Name = "Authorization",
+                    In = "header",
+                    Description = "JWT access token",
+                    Required = true,
+                    Type = "string",
+                    //Default = $"Bearer {token}"
+                });
+
+                operation.Responses.Add("401", new Response { Description = "Unauthorized" });
+                operation.Responses.Add("403", new Response { Description = "Forbidden" });
+
+                operation.Security = new List<IDictionary<string, IEnumerable<string>>>();
+
+                //Add JWT bearer type
+                operation.Security.Add(new Dictionary<string, IEnumerable<string>>
+                {
+                    { "Bearer", new string[] { } }
+                });
+            }
+        }
+    }
+}

--- a/backend/Filters/AddAuthHeaderOperationFilter.cs
+++ b/backend/Filters/AddAuthHeaderOperationFilter.cs
@@ -1,14 +1,14 @@
-using Swashbuckle.AspNetCore.Swagger;
-using Swashbuckle.AspNetCore.SwaggerGen;
-
-using Microsoft.OpenApi.Services;
+using Microsoft.AspNetCore.Http; 
+using Microsoft.AspNetCore.Mvc.Authorization; 
 using Microsoft.OpenApi.Models;
 
-using System;
-using System.Linq;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.AspNetCore.Http;
+using Swashbuckle.AspNetCore.Swagger; 
+using Swashbuckle.AspNetCore.SwaggerGen; 
+
+using System; 
+using System.Collections.Generic; 
+using System.Linq; 
+using System.Threading.Tasks;
 
 namespace OpenData.Filters {
 	public class AddAuthHeaderOperationFilter : IOperationFilter
@@ -26,32 +26,32 @@ namespace OpenData.Filters {
             var isAuthorized = filterDescriptor.Select(filterInfo => filterInfo.Filter).Any(filter => filter is AuthorizeFilter);
             var allowAnonymous = filterDescriptor.Select(filterInfo => filterInfo.Filter).Any(filter => filter is IAllowAnonymousFilter);
 
+            /*
             if (isAuthorized && !allowAnonymous)
             {
-                if (operation.Parameters == null)
-                    operation.Parameters = new List<IParameter>();
-
-                operation.Parameters.Add(new NonBodyParameter
-                {
-                    Name = "Authorization",
-                    In = "header",
-                    Description = "JWT access token",
-                    Required = true,
-                    Type = "string",
-                    //Default = $"Bearer {token}"
-                });
-
-                operation.Responses.Add("401", new Response { Description = "Unauthorized" });
-                operation.Responses.Add("403", new Response { Description = "Forbidden" });
-
-                operation.Security = new List<IDictionary<string, IEnumerable<string>>>();
-
+                operation.Responses.Add("401", new OpenApiResponse { Description = "Unauthorized" });
+                operation.Responses.Add("403", new OpenApiResponse { Description = "Forbidden" });
                 //Add JWT bearer type
-                operation.Security.Add(new Dictionary<string, IEnumerable<string>>
+                operation.Security.Add(new OpenApiSecurityRequirement
                 {
-                    { "Bearer", new string[] { } }
+                    {
+                        new OpenApiSecurityScheme
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.SecurityScheme,
+                                Id = "Bearer"
+                            },
+                            Scheme = "Bearer",
+                            Name = "Bearer",
+                            In = ParameterLocation.Header,
+
+                        },
+                        new List<string>()
+                    }
                 });
             }
+            */
         }
     }
 }

--- a/backend/Startup.cs
+++ b/backend/Startup.cs
@@ -18,12 +18,20 @@ using OpenData.Middleware;
 
 using System;
 using System.IO;
-using System.IdentityModel.Tokens.Jwt;
 using System.Text;
+using System.Collections.Generic ;
 using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
 
 using Microsoft.OpenApi.Models;
 using Microsoft.AspNetCore.Http;
+
+using Swashbuckle.AspNetCore.Swagger;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Services;
+
 
 namespace OpenData
 {
@@ -106,6 +114,36 @@ namespace OpenData
             {
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Description = "", Version = "v1" });
                 c.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, "backend.xml"));
+                c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+                {
+                    Description =
+                        "JWT Authorization header using the Bearer scheme. \r\n\r\n Enter 'Bearer' [space] and then your token in the text input below.\r\n\r\nExample: \"bearer 12345abcdef\"",
+                    Name = "Authorization",
+                    In = ParameterLocation.Header,
+                    Type = SecuritySchemeType.ApiKey,
+                    Scheme = "Bearer"
+                });
+
+                c.AddSecurityRequirement(new OpenApiSecurityRequirement()
+                {
+                    {
+                        new OpenApiSecurityScheme
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.SecurityScheme,
+                                Id = "Bearer"
+                            },
+                            Scheme = "oauth2",
+                            Name = "Bearer",
+                            In = ParameterLocation.Header,
+
+                        },
+                        new List<string>()
+                    }
+                });
+
+                c.OperationFilter<SecurityRequirementsOperationFilter>();
             }); 
         }
 

--- a/backend/Startup.cs
+++ b/backend/Startup.cs
@@ -130,7 +130,7 @@ namespace OpenData
                                 Type = ReferenceType.SecurityScheme,
                                 Id = "Bearer"
                             },
-                            Scheme = "oauth2",
+                            Scheme = "Bearer",
                             Name = "Bearer",
                             In = ParameterLocation.Header,
 
@@ -138,8 +138,7 @@ namespace OpenData
                         new List<string>()
                     }
                 });
-
-                c.OperationFilter<AuthorizationHeaderParameterOperationFilter>();
+                c.OperationFilter<AddAuthHeaderOperationFilter>();
             }); 
         }
 

--- a/backend/Startup.cs
+++ b/backend/Startup.cs
@@ -8,13 +8,14 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 //using Pomelo.EntityFrameworkCore.MySql.Infrastructure;
 
+using OpenData.Persistence.Repositories;
 using OpenData.Persistence.Contexts;
 using OpenData.Domain.Repositories;
 using OpenData.Domain.Services;
-using OpenData.Persistence.Repositories;
-using OpenData.Services;
 using OpenData.Domain.Models;
 using OpenData.Middleware;
+using OpenData.Services;
+using OpenData.Filters;
 
 using System;
 using System.IO;
@@ -27,11 +28,6 @@ using Microsoft.OpenApi.Models;
 using Microsoft.AspNetCore.Http;
 
 using Swashbuckle.AspNetCore.Swagger;
-using Swashbuckle.AspNetCore.SwaggerGen;
-
-using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Services;
-
 
 namespace OpenData
 {
@@ -143,7 +139,7 @@ namespace OpenData
                     }
                 });
 
-                c.OperationFilter<SecurityRequirementsOperationFilter>();
+                c.OperationFilter<AuthorizationHeaderParameterOperationFilter>();
             }); 
         }
 

--- a/backend/backend.csproj
+++ b/backend/backend.csproj
@@ -19,11 +19,11 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc5" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.1.0">
     </PackageReference>
+    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="5.0.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="3.1.1" />


### PR DESCRIPTION
I wasn't able to make swagger show which specific endpoints require authentication, but i added the framework for doing such. 

This PR introduces the bearer token to swagger, and contains a filter which could potentially later apply per-endpoint swagger metadata.