### PR TITLE
Add backend support for metadata categories

### DIFF
--- a/backend/Controllers/MetadataCategoryController.cs
+++ b/backend/Controllers/MetadataCategoryController.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+using AutoMapper;
+using OpenData.Domain.Models;
+using OpenData.Domain.Services;
+using OpenData.Domain.Repositories;
+using OpenData.Resources;
+using OpenData.Services;
+using OpenData.Extensions;
+using OpenData.Exceptions;
+using OpenData.Domain.Services.Communication;
+
+using System;
+using System.Net;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+
+namespace OpenData.Controllers
+{
+    [Authorize]
+	[Route("/api/[controller]")]
+	public class MetadataCategoryController : Controller
+	{
+		private readonly IMetadataCategoryService _metadataCategoryService;
+		private readonly IMapper _mapper;
+		private readonly IUnitOfWork _unitOfWork;
+		private readonly ILikeService _likeService;
+		private readonly IHttpContextAccessor httpContextRetriever;
+		private readonly IUserService userService;
+
+		public MetadataCategoryController(
+            IMetadataCategoryService metadataCategoryService,
+            IMapper mapper,
+            IUnitOfWork unitOfWork,
+			IHttpContextAccessor httpContextRetriever,
+            IUserService userService,
+            ILikeService likeService,
+			      ICommentService commentService
+            )
+		{
+			_metadataCategoryService = metadataCategoryService;
+			_mapper = mapper;
+			_unitOfWork = unitOfWork;
+			_likeService = likeService; 
+			this.httpContextRetriever = httpContextRetriever;
+			this.userService = userService;
+		}
+
+		/// <summary>
+		/// Returns a list of root nodes in the metadata category system
+		/// </summary> 
+        /// <returns>Root nodes</returns>
+		[AllowAnonymous]
+		[HttpGet]
+		public async Task<IEnumerable<MetadataCategoryResource>> GetRootNodesAsync()
+		{
+			var categories = await _metadataCategoryService.ListRootElementsAsync();
+			var resources = _mapper.Map<IEnumerable<MetadataCategory>, IEnumerable<MetadataCategoryResource>>(categories);
+			return resources;
+		}
+
+		/// <summary>
+		/// Returns a single category node
+		/// </summary>
+		/// <param name="uuid">UUID of the category to fetch</param>
+        /// <returns>The category node</returns>
+        [AllowAnonymous]
+		[HttpGet("{uuid}")]
+		public async Task<MetadataCategoryResource> GetCategory(string uuid)
+		{
+			try {
+				var category = await _metadataCategoryService.GetByUuidAsync(Guid.Parse(uuid));
+				var res = _mapper.Map<MetadataCategory, MetadataCategoryResource>(category);
+				return res;
+			} catch (Exception) {
+				throw new HttpException(HttpStatusCode.NotFound);
+			}
+		}
+
+		/// <summary>
+		/// Creates a category node.
+		/// </summary> 
+		/// <param name="category">The category node to be created</param>
+        /// <returns>The category node, if everything was successful</returns>
+		[HttpPut]
+		public async Task<IActionResult> PostAsync([FromBody] SaveMetadataCategoryResource categoryResource)
+		{
+			if (!ModelState.IsValid)
+				return BadRequest(ModelState.GetErrorMessages());
+
+			var username = httpContextRetriever.HttpContext.User.Identity.Name;
+			var user = await userService.GetUserByMailAsync(username);
+			if (user.UserType == UserType.Municipality)
+            {
+            	//Fetch the parent
+            	if(categoryResource.ParentUuid != null) {
+            		Guid guid = (Guid)categoryResource.ParentUuid;
+            		var parent = await _metadataCategoryService.GetByUuidAsync(guid);
+            		if(parent == null) {
+            			throw new HttpException(HttpStatusCode.NotFound);
+            		}
+            		parent.HasChildren = true;
+            	}
+
+				var category = _mapper.Map<SaveMetadataCategoryResource, MetadataCategory>(categoryResource);
+
+				var result = await _metadataCategoryService.SaveAsync(category);
+
+				if (!result.Success)
+					return BadRequest(result.Message);
+
+				var res = _mapper.Map<MetadataCategory, MetadataCategoryResource>(category);
+
+				await _unitOfWork.CompleteAsync();
+
+				return Ok(res);
+			}
+
+            return Unauthorized("Invalid permissions!");
+		}
+
+	}
+}

--- a/backend/Controllers/MetadataCategoryController.cs
+++ b/backend/Controllers/MetadataCategoryController.cs
@@ -68,10 +68,10 @@ namespace OpenData.Controllers
         /// <returns>The category node</returns>
         [AllowAnonymous]
 		[HttpGet("{uuid}")]
-		public async Task<MetadataCategoryResource> GetCategory(string uuid)
+		public async Task<MetadataCategoryResource> GetCategory(Guid uuid)
 		{
 			try {
-				var category = await _metadataCategoryService.GetByUuidAsync(Guid.Parse(uuid));
+				var category = await _metadataCategoryService.GetByUuidAsync(uuid);
 				var res = _mapper.Map<MetadataCategory, MetadataCategoryResource>(category);
 				return res;
 			} catch (Exception) {

--- a/backend/Domain/Models/Metadata.cs
+++ b/backend/Domain/Models/Metadata.cs
@@ -21,7 +21,7 @@ namespace OpenData.Domain.Models
 		public string MunicipalityName { get; set; }
 		public Municipality Owner { get; set; }
 		
-		public string MetadataTypeName { get; set; }
+		public Guid MetadataTypeUuid { get; set; }
 		public MetadataType Type { get; set; }
 
 		public IList<Like> Likes { get; set; }

--- a/backend/Domain/Models/MetadataCategory.cs
+++ b/backend/Domain/Models/MetadataCategory.cs
@@ -21,6 +21,7 @@ namespace OpenData.Domain.Models
         public DateTime LastEdited { get; set; }
 
         public bool HasChildren { get; set; } = false;
+        public bool HasTypes { get; set; } = false;
 
 #nullable enable
         public Guid? ParentUuid { get; set; }

--- a/backend/Domain/Models/MetadataCategory.cs
+++ b/backend/Domain/Models/MetadataCategory.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+
+namespace OpenData.Domain.Models
+{
+    public class MetadataCategory
+    {
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public Guid Uuid { get; set; }
+
+        [Required]
+        public string Name { get; set; }
+
+        [DatabaseGenerated(DatabaseGeneratedOption.Computed)]
+        public DateTime Created { get; set; }
+        
+        [DatabaseGenerated(DatabaseGeneratedOption.Computed)]
+        public DateTime LastEdited { get; set; }
+
+        public bool HasChildren { get; set; } = false;
+
+#nullable enable
+        public Guid? ParentUuid { get; set; }
+        public MetadataCategory? Parent { get; set; }
+#nullable disable
+
+        public IList<MetadataCategory> Children { get; set; }
+        public IList<MetadataType> Types { get; set; }
+    }
+}

--- a/backend/Domain/Models/MetadataType.cs
+++ b/backend/Domain/Models/MetadataType.cs
@@ -1,12 +1,21 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.ComponentModel.DataAnnotations;
 using System.Collections.Generic;
+using System;
 
 namespace OpenData.Domain.Models
 {
 	public class MetadataType
 	{
+		[DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+		public Guid Uuid { get; set; }
+
 		public string Name { get; set; }
 		public IList<MetadataTypeTagMapping> Tags { get; set; }
 		public string Description { get; set; }
 		public IList<Metadata> MetadataList { get; set; }
+
+		public Guid CategoryUuid { get; set; }
+		public MetadataCategory Category { get; set; }
 	}
 }

--- a/backend/Domain/Models/MetadataTypeTagMapping.cs
+++ b/backend/Domain/Models/MetadataTypeTagMapping.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System;
 
 namespace OpenData.Domain.Models
 {
@@ -8,7 +9,7 @@ namespace OpenData.Domain.Models
 
 		public Tag Tag { get; set; }
 
-		public string MetadataTypeName { get; set; }
+		public Guid MetadataTypeUuid { get; set; }
 		
 		public MetadataType Type { get; set; }
 	}

--- a/backend/Domain/Repositories/IMetadataCategoryRepository.cs
+++ b/backend/Domain/Repositories/IMetadataCategoryRepository.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System;
+
+using OpenData.Domain.Models;
+
+namespace OpenData.Domain.Repositories
+{
+    public interface IMetadataCategoryRepository
+    {
+        Task<IEnumerable<MetadataCategory>> ListRootElementsAsync();
+        Task<MetadataCategory> GetByUuidAsync(Guid uuid);
+        Task AddAsync(MetadataCategory category);
+    }
+}

--- a/backend/Domain/Repositories/IMetadataTypeRepository.cs
+++ b/backend/Domain/Repositories/IMetadataTypeRepository.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System;
+
 using OpenData.Domain.Models;
 using OpenData.Resources;
 
@@ -8,7 +10,7 @@ namespace OpenData.Domain.Repositories
     public interface IMetadataTypeRepository
     {
          Task<IEnumerable<MetadataType>> ListAsync();
-         Task<MetadataType> GetByNameAsync(string name);
+         Task<MetadataType> GetByUuidAsync(Guid uuid);
          Task AddAsync(MetadataType metadata);
          Task<IEnumerable<MetadataType>> FilterSearchAsync(MetadataTypeSearchParametersResource searchParams);
     }

--- a/backend/Domain/Services/Communication/SaveMetadataCategoryResponse.cs
+++ b/backend/Domain/Services/Communication/SaveMetadataCategoryResponse.cs
@@ -1,0 +1,30 @@
+using OpenData.Domain.Models;
+
+namespace OpenData.Domain.Services.Communication
+{
+    public class SaveMetadataCategoryResponse : BaseResponse
+    {
+        public MetadataCategory Category { get; private set; }
+
+        private SaveMetadataCategoryResponse(bool success, string message, MetadataCategory category) : base(success, message)
+        {
+            Category = category;
+        }
+
+        /// <summary>
+        /// Creates a success response.
+        /// </summary>
+        /// <param name="metadata">Saved metadata.</param>
+        /// <returns>Response.</returns>
+        public SaveMetadataCategoryResponse(MetadataCategory category) : this(true, string.Empty, category)
+        { }
+
+        /// <summary>
+        /// Creates am error response.
+        /// </summary>
+        /// <param name="message">Error message.</param>
+        /// <returns>Response.</returns>
+        public SaveMetadataCategoryResponse(string message) : this(false, message, null)
+        { }
+    }
+}

--- a/backend/Domain/Services/IMetadataCategoryService.cs
+++ b/backend/Domain/Services/IMetadataCategoryService.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System;
+
+using OpenData.Domain.Services.Communication;
+using OpenData.Domain.Models;
+
+namespace OpenData.Domain.Services
+{
+    public interface IMetadataCategoryService
+    {
+        Task<IEnumerable<MetadataCategory>> ListRootElementsAsync();
+        Task<MetadataCategory> GetByUuidAsync(Guid uuid);
+        Task<SaveMetadataCategoryResponse> SaveAsync(MetadataCategory category);
+    }
+}

--- a/backend/Domain/Services/IMetadataTypeService.cs
+++ b/backend/Domain/Services/IMetadataTypeService.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System;
+
 using OpenData.Domain.Models;
 using OpenData.Domain.Services.Communication;
 using OpenData.Resources;
@@ -9,7 +11,7 @@ namespace OpenData.Domain.Services
     public interface IMetadataTypeService
     {
          Task<IEnumerable<MetadataType>> ListAsync();
-         Task<MetadataType> GetByNameAsync(string name);
+         Task<MetadataType> GetByUuidAsync(Guid uuid);
          Task<SaveMetadataTypeResponse> SaveAsync(MetadataType metadata);
          Task<IEnumerable<MetadataType>> FilterSearchAsync(MetadataTypeSearchParametersResource searchParams);
     }

--- a/backend/Mapping/ModelToResourceProfile.cs
+++ b/backend/Mapping/ModelToResourceProfile.cs
@@ -14,6 +14,9 @@ namespace OpenData.Mapping
             CreateMap<MetadataType, MetadataTypeResource>();
 
             CreateMap<Metadata, MetadataResource>();
+            CreateMap<MetadataCategory, MetadataCategoryResource>();
+            CreateMap<MetadataCategory, MetadataCategoryChildResource>();
+            
             CreateMap<SaveMetadataResource, Metadata>();
             CreateMap<SaveMetadataTypeResource, MetadataType>();
 

--- a/backend/Persistence/Contexts/AppDbContext.cs
+++ b/backend/Persistence/Contexts/AppDbContext.cs
@@ -21,6 +21,7 @@ namespace OpenData.Persistence.Contexts
         public DbSet<Tag> Tags { get; set; }
         public DbSet<Like> Likes { get; set; }
         public DbSet<Comment> Comments { get; set; }
+        public DbSet<MetadataCategory> MetadataCategory { get; set; }
         public DbSet<MetadataCommentMapping> MetadataCommentMappings { get; set; }
         public DbSet<ExperiencePostCommentMapping> ExperiencePostCommentMappings { get; set; }
 
@@ -72,19 +73,51 @@ namespace OpenData.Persistence.Contexts
                 new DataFormat { Name = "CSV", Description = "Comma seperated values", DocumentationUrl = "https://tools.ietf.org/html/rfc4180"}
             );
 
+            builder.Entity<MetadataCategory>().ToTable("MetadataCategory");
+            builder.Entity<MetadataCategory>().HasKey(c => c.Uuid);
+            builder.Entity<MetadataCategory>().Property(c => c.Name).IsRequired();
+            builder.Entity<MetadataCategory>().Property(c => c.HasChildren).IsRequired();
+            builder.Entity<MetadataCategory>()
+                .HasMany(c => c.Children)
+                .WithOne(c => c.Parent)
+                .HasForeignKey(c => c.ParentUuid);
+            builder.Entity<MetadataCategory>()
+                .HasMany(c => c.Types)
+                .WithOne(c => c.Category)
+                .HasForeignKey(c => c.CategoryUuid);
+
+            //Build some tree structure we can play around with
+            var travel = new MetadataCategory { Uuid = Guid.NewGuid(), Name = "Travel", HasChildren = true};
+            var cars = new MetadataCategory { Uuid = Guid.NewGuid(), Name = "Cars", ParentUuid = travel.Uuid};
+            var bike = new MetadataCategory { Uuid = Guid.NewGuid(), Name = "Bikes", ParentUuid = travel.Uuid};
+            var population = new MetadataCategory { Uuid = Guid.NewGuid(), Name = "Population"};
+            var govtProp = new MetadataCategory { Uuid = Guid.NewGuid(), Name = "Government property", HasChildren = true};
+            var powerConsumption = new MetadataCategory { Uuid = Guid.NewGuid(), Name = "Power consumption", ParentUuid = govtProp.Uuid};
+
+            var health = new MetadataCategory { Uuid = Guid.NewGuid(), Name = "Health & wellbeing"};
+
+            var organization = new MetadataCategory { Uuid = Guid.NewGuid(), Name = "Organization and cooperation"};
+
+            builder.Entity<MetadataCategory>().HasData(
+                travel, cars, bike, govtProp, population, powerConsumption,
+                health, organization
+            );
+
             builder.Entity<MetadataType>().ToTable("MetadataTypes");
-            builder.Entity<MetadataType>().HasKey(p => p.Name);
-
+            builder.Entity<MetadataType>().HasKey(p => p.Uuid);
+            builder.Entity<MetadataType>().Property(nameof(MetadataType.Name)).IsRequired();
             builder.Entity<MetadataType>().Property(nameof(MetadataType.Description)).IsRequired();
-            builder.Entity<MetadataType>().HasMany(p => p.MetadataList).WithOne(p => p.Type).HasForeignKey(p => p.MetadataTypeName).IsRequired();
+            builder.Entity<MetadataType>().HasMany(p => p.MetadataList).WithOne(p => p.Type).HasForeignKey(p => p.MetadataTypeUuid).IsRequired();
 
+            //Define metadata types
+            var type_cycle = new MetadataType { Uuid = Guid.NewGuid(), Name = "Cycle history", CategoryUuid = bike.Uuid, Description = "Pling pling"};
+            var type_cycle_theft = new MetadataType { Uuid = Guid.NewGuid(), Name = "Cycle theft", CategoryUuid = bike.Uuid,  Description = "Some times, they get stolen."};
+            var type_population = new MetadataType { Uuid = Guid.NewGuid(), Name = "Populasjon", CategoryUuid = population.Uuid,  Description = "Informasjon om populasjonsdensitet"};
+            var type_kindergarden = new MetadataType { Uuid = Guid.NewGuid(), Name = "Kindergarden statistics", CategoryUuid = health.Uuid,  Description = "Kids grow faster in gardens"};
+            var type_corona = new MetadataType { Uuid = Guid.NewGuid(), Name = "Corona virus cases", CategoryUuid = health.Uuid,  Description = "Statistics about corona virus cases"};
+            var type_car = new MetadataType { Uuid = Guid.NewGuid(), Name = "Car history", CategoryUuid = cars.Uuid,  Description = "Wroom wroom"};
             builder.Entity<MetadataType>().HasData(
-                new MetadataType { Name = "Cycle history", Description = "Pling pling"},
-                new MetadataType { Name = "Cycle theft", Description = "Some times, they get stolen."},
-                new MetadataType { Name = "Populasjon", Description = "Informasjon om populasjonsdensitet"},
-                new MetadataType { Name = "Kindergarden statistics", Description = "Kids grow faster in gardens"},
-                new MetadataType { Name = "Corona virus cases", Description = "Statistics about corona virus cases"},
-                new MetadataType { Name = "Car history", Description = "Wroom wroom"}
+                type_cycle, type_cycle_theft, type_population, type_kindergarden, type_corona, type_car
             );
             
             builder.Entity<Metadata>().ToTable("Metadata");
@@ -102,30 +135,30 @@ namespace OpenData.Persistence.Contexts
             builder.Entity<Metadata>().HasData(
                 new Metadata { Uuid = Guid.NewGuid(), FormatName = "JSON", Url = "https://google.com", 
                                Description="Pling Plong", ReleaseState = EReleaseState.Released, MunicipalityName = "Trondheim",
-                               MetadataTypeName = "Cycle history"},
+                               MetadataTypeUuid = type_cycle.Uuid},
                 new Metadata { Uuid = Guid.NewGuid(), FormatName = "JSON", Url = "https://google.com", 
                                Description="We have a lot of bikes", ReleaseState = EReleaseState.Yellow, MunicipalityName = "Oslo",
-                               MetadataTypeName = "Cycle history"},
+                               MetadataTypeUuid = type_cycle.Uuid},
 
                 new Metadata { Uuid = Guid.NewGuid(), FormatName = "JSON", Url = "https://google.com", 
                                Description="Cycle theft for Trondheim. Contains city bike theft", ReleaseState = EReleaseState.Green, MunicipalityName = "Trondheim",
-                               MetadataTypeName = "Cycle theft"},
+                               MetadataTypeUuid = type_cycle_theft.Uuid},
                 new Metadata { Uuid = Guid.NewGuid(), FormatName = "JSON", Url = "https://google.com", 
                                Description="We have a lot of bikes. Some get stolen. Not the city bikes though.", ReleaseState = EReleaseState.Released, MunicipalityName = "Oslo",
-                               MetadataTypeName = "Cycle theft"},
+                               MetadataTypeUuid = type_cycle_theft.Uuid},
 
                 new Metadata { Uuid = Guid.NewGuid(), FormatName = "JSON", Url = "https://google.com", 
                                Description="", ReleaseState = EReleaseState.Released, MunicipalityName = "Trondheim",
-                               MetadataTypeName = "Populasjon"},
+                               MetadataTypeUuid = type_population.Uuid},
                 new Metadata { Uuid = Guid.NewGuid(), FormatName = "JSON", Url = "https://google.com", 
                                Description="", ReleaseState = EReleaseState.Green, MunicipalityName = "Oslo",
-                               MetadataTypeName = "Populasjon"},
+                               MetadataTypeUuid = type_population.Uuid},
                 new Metadata { Uuid = Guid.NewGuid(), FormatName = "JSON", Url = "https://google.com", 
                                Description="", ReleaseState = EReleaseState.Red, MunicipalityName = "Bodø",
-                               MetadataTypeName = "Populasjon"},
+                               MetadataTypeUuid = type_population.Uuid},
                 new Metadata { Uuid = Guid.NewGuid(), FormatName = "JSON", Url = "https://google.com", 
                                Description="", ReleaseState = EReleaseState.Released, MunicipalityName = "Test",
-                               MetadataTypeName = "Populasjon"}
+                               MetadataTypeUuid = type_population.Uuid}
             );
             
             builder.Entity<Comment>().ToTable("Comment");
@@ -139,6 +172,7 @@ namespace OpenData.Persistence.Contexts
                 .HasMany(c => c.ChildComments)
                 .WithOne(c => c.ParentComment)
                 .HasForeignKey(c => c.ParentCommentUuid);
+
 
             builder.Entity<MetadataCommentMapping>().HasKey(p => new { p.MetadataUuid, p.CommentUuid });
             builder.Entity<MetadataCommentMapping>()
@@ -162,8 +196,8 @@ namespace OpenData.Persistence.Contexts
             );
 
             builder.Entity<MetadataTypeTagMapping>().ToTable("MetadataTypeTagMapping");
-            builder.Entity<MetadataTypeTagMapping>().HasKey(p => new { p.TagName, p.MetadataTypeName });
-            builder.Entity<MetadataTypeTagMapping>().HasOne(p => p.Type).WithMany(p => p.Tags).HasForeignKey(p => p.MetadataTypeName);
+            builder.Entity<MetadataTypeTagMapping>().HasKey(p => new { p.TagName, p.MetadataTypeUuid });
+            builder.Entity<MetadataTypeTagMapping>().HasOne(p => p.Type).WithMany(p => p.Tags).HasForeignKey(p => p.MetadataTypeUuid);
             builder.Entity<MetadataTypeTagMapping>().HasOne(p => p.Tag).WithMany().HasForeignKey(p => p.TagName);
 
             builder.Entity<Like>().ToTable("Likes");
@@ -172,9 +206,9 @@ namespace OpenData.Persistence.Contexts
             builder.Entity<Like>().HasOne(p => p.Metadata).WithMany(p => p.Likes).HasForeignKey(p => p.MetadataUuid);
 
             builder.Entity<MetadataTypeTagMapping>().HasData(
-                new MetadataTypeTagMapping { TagName = "Public activity", MetadataTypeName = "Cycle History"},
-                new MetadataTypeTagMapping { TagName = "Public activity", MetadataTypeName = "Car History"},
-                new MetadataTypeTagMapping { TagName = "Traffic", MetadataTypeName = "Car History"}
+                new MetadataTypeTagMapping { TagName = "Public activity", MetadataTypeUuid = type_cycle.Uuid},
+                new MetadataTypeTagMapping { TagName = "Public activity", MetadataTypeUuid = type_car.Uuid},
+                new MetadataTypeTagMapping { TagName = "Traffic", MetadataTypeUuid = type_car.Uuid}
             );
 
             builder.Entity<ExperiencePost>().ToTable("ExperiencePost");

--- a/backend/Persistence/Repositories/MetadataCategoryRepository.cs
+++ b/backend/Persistence/Repositories/MetadataCategoryRepository.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using OpenData.Domain.Models;
+using OpenData.Domain.Repositories;
+using OpenData.Persistence.Contexts;
+using System.Linq;
+using System.Web;
+using System;
+
+namespace OpenData.Persistence.Repositories
+{
+    public class MetadataCategoryRepository : BaseRepository, IMetadataCategoryRepository
+    {
+        public MetadataCategoryRepository(AppDbContext context) : base(context)
+        {
+
+        }
+
+        public async Task<IEnumerable<MetadataCategory>> ListRootElementsAsync()
+        {
+            return await _context.MetadataCategory.Where(m => m.Parent == null).Include(x => x.Children).ThenInclude(x => x.Types).Include(x => x.Types).ToListAsync();
+        }
+
+        public async Task<MetadataCategory> GetByUuidAsync(Guid uuid) {
+            return await _context.MetadataCategory.Include(x => x.Children).ThenInclude(x => x.Types).Include(x => x.Types).FirstAsync(x => x.Uuid == uuid);
+        }
+
+        public async Task AddAsync(MetadataCategory category) {
+            await _context.MetadataCategory.AddAsync(category);
+        }
+    }
+}

--- a/backend/Persistence/Repositories/MetadataCategoryRepository.cs
+++ b/backend/Persistence/Repositories/MetadataCategoryRepository.cs
@@ -19,11 +19,20 @@ namespace OpenData.Persistence.Repositories
 
         public async Task<IEnumerable<MetadataCategory>> ListRootElementsAsync()
         {
-            return await _context.MetadataCategory.Where(m => m.Parent == null).Include(x => x.Children).ThenInclude(x => x.Types).Include(x => x.Types).ToListAsync();
+            return await _context.MetadataCategory
+                .Where(m => m.Parent == null)
+                .Include(x => x.Children)
+                    .ThenInclude(x => x.Types)
+                .Include(x => x.Types)
+                .ToListAsync();
         }
 
         public async Task<MetadataCategory> GetByUuidAsync(Guid uuid) {
-            return await _context.MetadataCategory.Include(x => x.Children).ThenInclude(x => x.Types).Include(x => x.Types).FirstAsync(x => x.Uuid == uuid);
+            return await _context.MetadataCategory
+                .Include(x => x.Children)
+                    .ThenInclude(x => x.Types)
+                .Include(x => x.Types)
+                .FirstAsync(x => x.Uuid == uuid);
         }
 
         public async Task AddAsync(MetadataCategory category) {

--- a/backend/Persistence/Repositories/MetadataTypeRepository.cs
+++ b/backend/Persistence/Repositories/MetadataTypeRepository.cs
@@ -22,8 +22,8 @@ namespace OpenData.Persistence.Repositories
             return await _context.MetadataTypes.Include(p => p.Tags).ToListAsync();
         }
 
-        public async Task<MetadataType> GetByNameAsync(string name) {
-            return await _context.MetadataTypes.Include(p => p.Tags).Include(p => p.MetadataList).ThenInclude(p => p.Format).FirstAsync(x => x.Name == name);
+        public async Task<MetadataType> GetByUuidAsync(Guid uuid) {
+            return await _context.MetadataTypes.Include(p => p.Tags).Include(p => p.MetadataList).ThenInclude(p => p.Format).FirstAsync(x => x.Uuid == uuid);
         }
 
         public async Task AddAsync(MetadataType metadata) {

--- a/backend/Persistence/Repositories/MetadataTypeRepository.cs
+++ b/backend/Persistence/Repositories/MetadataTypeRepository.cs
@@ -23,7 +23,11 @@ namespace OpenData.Persistence.Repositories
         }
 
         public async Task<MetadataType> GetByUuidAsync(Guid uuid) {
-            return await _context.MetadataTypes.Include(p => p.Tags).Include(p => p.MetadataList).ThenInclude(p => p.Format).FirstAsync(x => x.Uuid == uuid);
+            return await _context.MetadataTypes
+                .Include(p => p.Tags)
+                .Include(p => p.MetadataList)
+                    .ThenInclude(p => p.Format)
+                .FirstAsync(x => x.Uuid == uuid);
         }
 
         public async Task AddAsync(MetadataType metadata) {

--- a/backend/Resources/MetadataCategoryChildResource.cs
+++ b/backend/Resources/MetadataCategoryChildResource.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System;
+
+using OpenData.Domain.Models;
+
+namespace OpenData.Resources
+{
+        public class MetadataCategoryChildResource
+        {
+                public Guid Uuid { get; set; }
+
+                public string Name { get; set; }
+
+                public bool HasChildren { get; set; } = false;
+
+                public IList<MetadataCategoryChildResource> Children { get; set; }
+                public IList<MetadataTypeResource> Types { get; set; }
+	}
+}

--- a/backend/Resources/MetadataCategoryResource.cs
+++ b/backend/Resources/MetadataCategoryResource.cs
@@ -16,6 +16,7 @@ namespace OpenData.Resources
                 public DateTime LastEdited { get; set; }
 
                 public bool HasChildren { get; set; } = false;
+                public bool HasTypes { get; set; } = false;
 
 #nullable enable
                 public Guid? ParentUuid { get; set; }

--- a/backend/Resources/MetadataCategoryResource.cs
+++ b/backend/Resources/MetadataCategoryResource.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System;
+
+using OpenData.Domain.Models;
+
+namespace OpenData.Resources
+{
+        public class MetadataCategoryResource
+        {
+                public Guid Uuid { get; set; }
+
+                public string Name { get; set; }
+
+                public DateTime Created { get; set; }
+                
+                public DateTime LastEdited { get; set; }
+
+                public bool HasChildren { get; set; } = false;
+
+#nullable enable
+                public Guid? ParentUuid { get; set; }
+#nullable disable
+
+                public IList<MetadataCategoryChildResource> Children { get; set; }
+                public IList<MetadataTypeResource> Types { get; set; }
+	}
+}

--- a/backend/Resources/MetadataTypeResource.cs
+++ b/backend/Resources/MetadataTypeResource.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System;
 
 namespace OpenData.Domain.Models
 {
@@ -8,5 +9,7 @@ namespace OpenData.Domain.Models
 		public IList<MetadataTypeTagMappingResource> Tags { get; set; }
 		public string Description { get; set; }
 		public IList<MetadataResource> MetadataList { get; set; }
+
+		public Guid CategoryUuid { get; set; }
 	}
 }

--- a/backend/Resources/MetadataTypeTagMappingResource.cs
+++ b/backend/Resources/MetadataTypeTagMappingResource.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System;
 
 namespace OpenData.Domain.Models
 {
@@ -6,7 +7,7 @@ namespace OpenData.Domain.Models
 	{
 		public string TagName { get; set; }
 
-		public string MetadataTypeName { get; set; }
+		public Guid MetadataTypeUuid { get; set; }
 		
 	}
 }

--- a/backend/Resources/SaveMetadataCategoryResource.cs
+++ b/backend/Resources/SaveMetadataCategoryResource.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System;
+
+namespace OpenData.Resources
+{
+	///<summary>
+	///Represents the required fields for the creation of a metadata object
+	///</summary>
+	public class SaveMetadataCategoryResource
+	{
+		[MaxLength(128)]
+		public string Name { get; set; }
+
+		public Guid? ParentUuid { get; set; }
+	}
+}

--- a/backend/Resources/SaveMetadataTypeResource.cs
+++ b/backend/Resources/SaveMetadataTypeResource.cs
@@ -1,10 +1,19 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using System.ComponentModel.DataAnnotations;
 using System.Collections.Generic;
+using System;
 
 namespace OpenData.Domain.Models
 {
 	public class SaveMetadataTypeResource
 	{
+		[Required]
 		public string Name { get; set; }
+		
+		[Required]
 		public string Description { get; set; }
+
+		[Required]
+		public Guid CategoryUuid { get; set; }
 	}
 }

--- a/backend/Services/MetadataCategoryService.cs
+++ b/backend/Services/MetadataCategoryService.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System;
+
+using OpenData.Domain.Models;
+using OpenData.Domain.Repositories;
+using OpenData.Domain.Services;
+using OpenData.Domain.Services.Communication;
+
+namespace OpenData.Services
+{
+    public class MetadataCategoryService : IMetadataCategoryService
+    {
+    	private readonly IMetadataCategoryRepository _metadataCategoryRepository;
+
+    	public MetadataCategoryService(IMetadataCategoryRepository metadataCategoryRepository) 
+    	{
+    		_metadataCategoryRepository = metadataCategoryRepository;
+    	}
+
+        public async Task<IEnumerable<MetadataCategory>> ListRootElementsAsync()
+        {
+        	return await _metadataCategoryRepository.ListRootElementsAsync();
+        }
+
+        public async Task<MetadataCategory> GetByUuidAsync(Guid uuid) {
+            return await _metadataCategoryRepository.GetByUuidAsync(uuid);
+        }
+
+        public async Task<SaveMetadataCategoryResponse> SaveAsync(MetadataCategory category) {
+            try
+            {
+                await _metadataCategoryRepository.AddAsync(category);
+                
+                return new SaveMetadataCategoryResponse(category);
+            }
+            catch (Exception ex)
+            {
+                // Do some logging stuff
+                return new SaveMetadataCategoryResponse($"An error occurred when saving the category: {ex.Message}");
+            }
+        }
+    }
+}

--- a/backend/Services/MetadataTypeService.cs
+++ b/backend/Services/MetadataTypeService.cs
@@ -23,8 +23,8 @@ namespace OpenData.Services
         	return await _metadataTypeRepository.ListAsync();
         }
 
-        public async Task<MetadataType> GetByNameAsync(string name) {
-            return await _metadataTypeRepository.GetByNameAsync(name);
+        public async Task<MetadataType> GetByUuidAsync(Guid uuid){
+            return await _metadataTypeRepository.GetByUuidAsync(uuid);
         }
 
         public async Task<SaveMetadataTypeResponse> SaveAsync(MetadataType metadata) {

--- a/backend/Startup.cs
+++ b/backend/Startup.cs
@@ -86,6 +86,9 @@ namespace OpenData
             services.AddScoped<IMetadataRepository, MetadataRepository>();
             services.AddScoped<IMetadataService, MetadataService>();
 
+            services.AddScoped<IMetadataCategoryRepository, MetadataCategoryRepository>();
+            services.AddScoped<IMetadataCategoryService, MetadataCategoryService>();
+
             services.AddScoped<IExperiencePostRepository, ExperiencePostRepository>();
             services.AddScoped<IExperiencePostService, ExperiencePostService>();
 


### PR DESCRIPTION
Also refactors MetadataType so it has a primary key UUID.

Example format for the categories:

`GET /api/MetadataCategory/`
```
[
  {
    "uuid": "534895ee-a24f-439b-9d99-db006ba8fd22",
    "name": "Travel",
    "created": "2020-03-17T16:52:37.103373",
    "lastEdited": "2020-03-17T16:52:37.103373",
    "hasChildren": true,
    "parentUuid": null,
    "children": [
      {
        "uuid": "4dec3103-3995-4c83-86e8-a1258b5cefe2",
        "name": "Cars",
        "hasChildren": false,
        "children": [],
        "types": [
          {
            "name": "Car history",
            "tags": [],
            "description": "Wroom wroom",
            "metadataList": [],
            "categoryUuid": "4dec3103-3995-4c83-86e8-a1258b5cefe2"
          }
        ]
      },
      {
        "uuid": "514b3bb3-c222-402e-acd8-4bc737a78226",
        "name": "Bikes",
        "hasChildren": false,
        "children": [],
        "types": [
          {
            "name": "Cycle history",
            "tags": [],
            "description": "Pling pling",
            "metadataList": [],
            "categoryUuid": "514b3bb3-c222-402e-acd8-4bc737a78226"
          },
          {
            "name": "Cycle theft",
            "tags": [],
            "description": "Some times, they get stolen.",
            "metadataList": [],
            "categoryUuid": "514b3bb3-c222-402e-acd8-4bc737a78226"
          }
        ]
      }
    ],
    "types": []
  },
  {
    "uuid": "96f835df-f317-4aa9-8749-81eeefe7a0f7",
    "name": "Population",
    "created": "2020-03-17T16:52:37.114641",
    "lastEdited": "2020-03-17T16:52:37.114641",
    "hasChildren": false,
    "parentUuid": null,
    "children": [],
    "types": [
      {
        "name": "Populasjon",
        "tags": [],
        "description": "Informasjon om populasjonsdensitet",
        "metadataList": [],
        "categoryUuid": "96f835df-f317-4aa9-8749-81eeefe7a0f7"
      }
    ]
  },
  {
    "uuid": "9ff63576-2b78-42e5-8466-e16dc9938d6d",
    "name": "Government property",
    "created": "2020-03-17T16:52:37.111741",
    "lastEdited": "2020-03-17T16:52:37.111741",
    "hasChildren": true,
    "parentUuid": null,
    "children": [
      {
        "uuid": "b86b4520-f9da-4e4b-bd84-e321a0ee8247",
        "name": "Power consumption",
        "hasChildren": false,
        "children": [],
        "types": []
      }
    ],
    "types": []
  },
  {
    "uuid": "bbc0d3d9-174a-4ce0-95c3-4a2e20335227",
    "name": "Organization and cooperation",
    "created": "2020-03-17T16:52:37.124512",
    "lastEdited": "2020-03-17T16:52:37.124512",
    "hasChildren": false,
    "parentUuid": null,
    "children": [],
    "types": []
  },
  {
    "uuid": "bce13f43-60bb-417d-a456-470a3560765b",
    "name": "Health & wellbeing",
    "created": "2020-03-17T16:52:37.12353",
    "lastEdited": "2020-03-17T16:52:37.12353",
    "hasChildren": false,
    "parentUuid": null,
    "children": [],
    "types": [
      {
        "name": "Corona virus cases",
        "tags": [],
        "description": "Statistics about corona virus cases",
        "metadataList": [],
        "categoryUuid": "bce13f43-60bb-417d-a456-470a3560765b"
      },
      {
        "name": "Kindergarden statistics",
        "tags": [],
        "description": "Kids grow faster in gardens",
        "metadataList": [],
        "categoryUuid": "bce13f43-60bb-417d-a456-470a3560765b"
      }
    ]
  }
]
```