### PR TITLE
Change footer to use NTNU's official english name

### DIFF
--- a/frontend/src/sharedComponents/Footer.jsx
+++ b/frontend/src/sharedComponents/Footer.jsx
@@ -26,7 +26,7 @@ const Footer = () => (
     <Container>
       <p>
         OpenData is an open source data catalogue developed at the
-        Norwegian University of Technology and Science in Trondheim, Norway.
+        Norwegian University of Science and Technology in Trondheim, Norway.
       </p>
       <p>
         <Link href="https://github.com/OpenDataNTNU/OpenData">


### PR DESCRIPTION
Changed footer to say Science and Technology, rather than technology and Science