### PR TITLE
Add a basic form for creating new categories

### DIFF
--- a/frontend/src/pages/NewCategory/index.jsx
+++ b/frontend/src/pages/NewCategory/index.jsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { useDispatch, useSelector } from 'react-redux';
+import { Redirect } from 'react-router-dom';
+
+import { Template } from '../../sharedComponents/Template';
+import { RootLevelCategorySelector } from '../NewMetadataType/RootLevelCategorySelector';
+import { alertActions } from '../../state/actions/alert';
+
+const Background = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  max-width: 960px;
+  margin: auto;
+  box-sizing: border-box;
+
+  @media screen and (max-width: 960px) {
+    padding: 5px;
+  }
+`;
+
+const Form = styled.form`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  align-content: center;
+  justify-content: center;
+  justify-items: center;
+  width: 100%;
+  margin: 10px 0px;
+`;
+
+export const NewCategory = () => {
+  const [name, setName] = useState('');
+  const [parentCategory, setParentCategory] = useState(undefined);
+  const [redirect, setRedirect] = useState(false);
+
+  const dispatch = useDispatch();
+  const userSelector = useSelector((state) => state.user);
+
+  const submit = async (e) => {
+    e.preventDefault();
+    if (!name) {
+      dispatch(alertActions.error('Please enter a name for the new category'));
+      return;
+    }
+    if (parentCategory === undefined) {
+      dispatch(alertActions.error('Please choose a parent category (or "[No category]", if this is not a subcategory)'));
+      return;
+    }
+    try {
+      const { token } = userSelector.user;
+      const { ok, status } = await fetch('/api/MetadataCategory', {
+        method: 'PUT',
+        body: JSON.stringify({
+          name,
+          parentUuid: parentCategory || null,
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `bearer ${token}`,
+        },
+      });
+      if (!ok) {
+        const err = new Error();
+        err.status = status;
+        throw err;
+      }
+      setTimeout(() => {
+        setRedirect(true);
+      }, 3000);
+      dispatch(alertActions.success('Successfully submitted category. Redirecting in 3 seconds.'));
+    } catch (err) {
+      const { status } = err;
+      if (status === 401) {
+        dispatch(alertActions.error('Unauthorized to create a new category'));
+      } else {
+        dispatch(alertActions.error('An unexpected error occurred while creating a new category.'));
+      }
+    }
+  };
+
+  if (redirect) {
+    return <Redirect to="/newMetadataType" />;
+  }
+
+  return (
+    <Template>
+      <Background>
+        <Form onSubmit={submit}>
+          <h2>
+            Create a new category
+          </h2>
+          <input type="text" value={name} onChange={(e) => setName(e.target.value)} placeholder="Name for new category" />
+          <RootLevelCategorySelector nullable title="Parent category:" onChange={(e) => setParentCategory(e.target.value)} />
+          <input type="submit" value="Submit" />
+        </Form>
+      </Background>
+    </Template>
+  );
+};

--- a/frontend/src/pages/NewMetadataType/NewMetadataTypeBody.jsx
+++ b/frontend/src/pages/NewMetadataType/NewMetadataTypeBody.jsx
@@ -155,12 +155,19 @@ export const NewMetadataTypeBody = () => {
         <Input type="text" value={name} onChange={(e) => setName(e.target.value)} placeholder="Name" required />
         <TextArea value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Description" required />
         <Select data={allTags || []} value={tags} onChange={setTags} placeholder="Tags" />
-        <RootLevelCategorySelector onChange={onCategoryChange} />
         <NewTag>
           Are none of these tags appropriate?
           {' '}
           <Link to="/tags/new">
             <b>Create a new one</b>
+          </Link>
+        </NewTag>
+        <RootLevelCategorySelector onChange={onCategoryChange} />
+        <NewTag>
+          Are none of these categories appropriate?
+          {' '}
+          <Link to="/newCategory">
+            <b>Create a new one here</b>
           </Link>
         </NewTag>
         <LoadingButton text="submit" type="value" loading={loading} onClick={() => {}} />

--- a/frontend/src/pages/NewMetadataType/RootLevelCategorySelector.jsx
+++ b/frontend/src/pages/NewMetadataType/RootLevelCategorySelector.jsx
@@ -5,7 +5,7 @@ import { useDispatch } from 'react-redux';
 import { CategorySelector } from './CategorySelector';
 import { alertActions } from '../../state/actions/alert';
 
-export const RootLevelCategorySelector = ({ onChange }) => {
+export const RootLevelCategorySelector = ({ onChange, nullable, title }) => {
   const [categories, setCategories] = useState([]);
 
   const dispatch = useDispatch();
@@ -31,8 +31,18 @@ export const RootLevelCategorySelector = ({ onChange }) => {
 
   return (
     <>
-      <h3>Category:</h3>
+      <h3>{title}</h3>
       <ul>
+        { nullable
+          ? (
+            <li>
+              <label>
+                [No category]
+                <input type="radio" name="category" value="" onChange={onChange} />
+              </label>
+            </li>
+          )
+          : null}
         {categories.map((category) => (
           <CategorySelector key={category.uuid} category={category} onChange={onChange} />
         ))}
@@ -43,4 +53,11 @@ export const RootLevelCategorySelector = ({ onChange }) => {
 
 RootLevelCategorySelector.propTypes = {
   onChange: PropTypes.func.isRequired,
+  nullable: PropTypes.bool,
+  title: PropTypes.string,
+};
+
+RootLevelCategorySelector.defaultProps = {
+  nullable: false,
+  title: 'Category:',
 };

--- a/frontend/src/router/router.jsx
+++ b/frontend/src/router/router.jsx
@@ -28,6 +28,7 @@ import { Category } from '../pages/Category';
 import { EditDescriptionMetadataType } from '../pages/EditDescriptionMetadataType';
 import { DCATWizard } from '../pages/DCATWizard';
 import { About } from '../pages/About';
+import { NewCategory } from '../pages/NewCategory';
 
 const RouterComponent = () => { // eslint-disable-line arrow-body-style
   return (
@@ -44,6 +45,7 @@ const RouterComponent = () => { // eslint-disable-line arrow-body-style
         <Route path="/search" component={Search} />
         <Route path="/category/:uuid" component={Category} />
         <Route path="/category" component={Category} />
+        <PrivateRoute path="/newCategory" municipality component={NewCategory} />
         <PrivateRoute path="/sendData" municipality component={SendMetadata} />
         <PrivateRoute path="/articles/new/:id" municipality component={NewExperienceArticle} />
         <PrivateRoute path="/articles/new" municipality component={NewExperienceArticle} />


### PR DESCRIPTION
Added a simple form for creating new categories, available at `/newCategory`. This is linked to from the new metadata type-form, which (as far as I know) is the only case in which someone might require to create a new category. 

This PR is dependent on PR #232 in order for the PUT requests to work. No need to check out this branch until that PR is processed.