### PR TITLE
Fixed broken /tags height

### DIFF
--- a/frontend/src/pages/Tags/index.jsx
+++ b/frontend/src/pages/Tags/index.jsx
@@ -16,7 +16,6 @@ const Wrapper = styled.div`
 `;
 
 const Contents = styled.div`
-  max-height: 50%;
   display: flex;
   flex-direction: column;
   align-content: space-around;


### PR DESCRIPTION
Now looks like this:
![image](https://puu.sh/FH8ln/b9aebf6daa.png)

As opposed to this:
![image](https://user-images.githubusercontent.com/23093283/81222163-25571180-8fe4-11ea-859b-b2fc715c9de4.png)
